### PR TITLE
DRY up minister and policy minister selection

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,3 @@ ParliamentaryQuestions::Application.load_tasks
 
 # Disable the requirement for pg_dump on production
 Rake::Task["db:structure:dump"].clear if Rails.env.production?
-
-task :default do
-  Brakeman.run :app_path => ".", :print_report => true
-end

--- a/app/controllers/pqs_controller.rb
+++ b/app/controllers/pqs_controller.rb
@@ -6,8 +6,6 @@ class PqsController < ApplicationController
   before_action :prepare_ogds
   before_action :load_service
 
-  helper_method :minister_warning?, :policy_minister_warning?
-
   def index
     redirect_to controller: 'dashboard'
   end
@@ -18,9 +16,6 @@ class PqsController < ApplicationController
       flash[:notice] = 'Question not found'
       redirect_to action: 'index'
     end
-
-    prepare_ministers(@pq)
-    @pq
   end
 
   def update
@@ -31,7 +26,6 @@ class PqsController < ApplicationController
       return redirect_to action:'show', id: @pq.uin
     end
 
-    prepare_ministers(@pq)
     render action: 'show'
   end
 
@@ -89,29 +83,6 @@ class PqsController < ApplicationController
         :transfer_in_date,
         :date_for_answer
     )
-  end
-
-  def prepare_ministers(pq)
-    all_active = Minister.all_active
-
-    @minister_list = prepend_minister_unless_included(all_active, pq.minister)
-    @policy_minister_list = prepend_minister_unless_included(all_active, pq.policy_minister)
-  end
-
-  def minister_warning?
-    !@pq.closed? && !@pq.minister.nil? && @pq.minister.deleted?
-  end
-
-  def policy_minister_warning?
-    !@pq.closed? && !@pq.policy_minister.nil? && @pq.policy_minister.deleted?
-  end
-
-  def prepend_minister_unless_included(list, minister)
-    unless minister.nil? || list.include?(minister)
-      [minister] + list
-    else
-      list
-    end
   end
 
   def assignment_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,4 +36,16 @@ module ApplicationHelper
         flash_type.to_s
     end
   end
+
+  def minister_warning?(question, minister)
+    question.present? && question.open? && minister.try(:deleted?)
+  end
+
+  def ministers(question)
+    Minister.active(question.try(:minister))
+  end
+
+  def policy_ministers(question)
+    Minister.active(question.try(:policy_minister))
+  end
 end

--- a/app/models/minister.rb
+++ b/app/models/minister.rb
@@ -17,8 +17,11 @@ class Minister < ActiveRecord::Base
     self.name + (self.deleted ? ' - Inactive' : '')
   end
 
-  def self.all_active
-    Minister.where(deleted: false)
+  def self.active(minister = nil)
+    table = Minister.arel_table
+    arel = table[:deleted].eq(false)
+    arel = arel.or(table[:id].eq(minister.id)) if minister
+    where(arel)
   end
 
   private

--- a/app/models/pq.rb
+++ b/app/models/pq.rb
@@ -58,6 +58,10 @@ class Pq < ActiveRecord::Base
     end
   end
 
+  def open?
+    !closed?
+  end
+
   def is_in_progress?(pro)
     progress_id == pro.id
   end

--- a/app/views/dashboard/_question_data_uncommissioned.html.erb
+++ b/app/views/dashboard/_question_data_uncommissioned.html.erb
@@ -10,15 +10,7 @@
                 <% disabled = !question.seen_by_finance %>
 
                 <fieldset>
-                    <div id="answering-minister-form-<%= question.id %>" class="minister-dropdown form-group">
-                        <label for="minister_id" class="form-label">Assign answering minister</label>
-                        <%= select_tag 'commission_form[minister_id]', content_tag(:option, 'Select', :value => '') + options_from_collection_for_select(Minister.all_active, 'id', 'name', question.minister_id), class: 'single-select-dropdown form-control required-for-commission', disabled: disabled %>
-                    </div>
-
-                    <div id="policy-minister-form-<%= question.id %>" class="minister-dropdown form-group">
-                        <label for="minister_id" class="form-label">Assign policy minister</label>
-                        <%= select_tag 'commission_form[policy_minister_id]', content_tag(:option, 'Select', :value => '') + options_from_collection_for_select(Minister.all_active, 'id', 'name', question.policy_minister_id), class: 'single-select-dropdown form-control', disabled: disabled %>
-                    </div>
+                    <%= render partial: 'shared/minister_selection', locals: {question: @pq, form: f} %>
 
                     <div id="comm-form-container-<%= question.id %>" class="allocation-info form-group">
                         <label class="form-label">Assign action officer(s)</label>

--- a/app/views/pqs/_com_data.html.erb
+++ b/app/views/pqs/_com_data.html.erb
@@ -5,7 +5,7 @@
   <span class='input-group date internal-deadline-picker' id='datetimepicker1' data-date-format="DD/MM/YYYY HH:mm">
     <input id="pq_internal_deadline" class="form-control" name="pq[internal_deadline]" type="text" value="<%= @pq.internal_deadline.strftime('%d/%m/%Y %H:%M') unless @pq.internal_deadline.nil? %>">
     <span class="input-group-addon glyphicon glyphicon-calendar"></span>
-  </span>  
+  </span>
 </div>
 <hr/>
 <div class="question-allocation">
@@ -50,20 +50,8 @@
   <%= render partial:'shared/rejected_reasons', locals: {question: @pq} %>
 </div>
 <hr/>
-<div class="form-group">
-  <label for="pq_minister_id" class="form-label">Replying minister</label>
-  <%= f.collection_select(:minister_id, @minister_list, :id, :name_with_inactive_status, { :include_blank => ''}, { class: 'minister-select' } ) %>
-  <% if minister_warning? %>
-    <%= render('shared/warning_icon')  %>
-  <% end %>
-</div>
-<div class="form-group">
-  <label for="pq_policy_minister_id" class="form-label">Optional policy minister</label>
-  <%= f.collection_select(:policy_minister_id, @policy_minister_list, :id, :name_with_inactive_status, { :include_blank => ''}, { class: 'minister-select' }) %>
-  <% if policy_minister_warning? %>
-    <%= render('shared/warning_icon')  %>
-  <% end %>
-</div>
+<%= render partial: 'shared/minister_selection', locals: {question: @pq, form: f} %>
+
 <hr/>
 <div class="form-group">
   <label for="pq_transfer_out_ogd_id" class="form-label">Transfer out to</label>
@@ -76,4 +64,3 @@
     <span class="input-group-addon glyphicon glyphicon-calendar"></span>
   </span>
 </div>
-

--- a/app/views/shared/_minister_selection.html.erb
+++ b/app/views/shared/_minister_selection.html.erb
@@ -1,0 +1,10 @@
+<div id="answering-minister-form-<%= question.try(:id) %>" class="minister-dropdown form-group">
+  <label for="pq_minister_id" class="form-label">Answering minister</label>
+  <%= form.collection_select(:minister_id, ministers(question), :id, :name_with_inactive_status, { :include_blank => ''}, { class: 'minister-select', disabled: !question.try(:seen_by_finance) }) %>
+  <%= render('shared/warning_icon') if minister_warning?(question, question.minister) %>
+</div>
+<div id="policy-minister-form-<%= question.try(:id) %>" class="minister-dropdown form-group">
+  <label for="pq_policy_minister_id" class="form-label">Policy minister (Optional)</label>
+  <%= form.collection_select(:policy_minister_id, policy_ministers(question), :id, :name_with_inactive_status, { :include_blank => ''}, { class: 'minister-select', disabled: !question.try(:seen_by_finance) }) %>
+  <%= render('shared/warning_icon') if policy_minister_warning?(question, question.policy_minister) %>
+</div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.describe ApplicationHelper do
+  describe '#minister_warning?' do
+    it 'false when no question' do
+      expect(helper.minister_warning?(nil, nil)).to be false
+    end
+
+    it 'false when not open' do
+      question = build(:answered_pq)
+      expect(helper.minister_warning?(question, nil)).to be false
+    end
+
+    it 'false when no minister' do
+      question = build(:Pq)
+      minister = nil
+      expect(helper.minister_warning?(question, minister)).to be nil
+    end
+
+    it 'false when minister not deleted' do
+      question = build(:Pq)
+      minister = build(:minister)
+      expect(helper.minister_warning?(question, minister)).to be false
+    end
+
+    it 'true when minister deleted' do
+      question = build(:Pq)
+      minister = build(:deleted_minister)
+      expect(helper.minister_warning?(question, minister)).to be true
+    end
+  end
+
+  describe '#ministers' do
+    let(:minister) { double }
+    let(:question) { double minister: minister }
+    before { expect(Minister).to receive(:active).with(minister) }
+
+    it 'returns active ministers including selected' do
+      helper.ministers(question)
+    end
+  end
+
+  describe '#policy_ministers' do
+    let(:minister) { double }
+    let(:question) { double policy_minister: minister }
+    before { expect(Minister).to receive(:active).with(minister) }
+
+    it 'returns active ministers including selected' do
+      helper.policy_ministers(question)
+    end
+  end
+end

--- a/spec/models/minister_spec.rb
+++ b/spec/models/minister_spec.rb
@@ -40,16 +40,22 @@ describe Minister do
     end
   end
 
-  describe '::all_active' do
-    let!(:minister) { create(:minister) }
-    let!(:deleted_minister) { create(:deleted_minister) }
-    subject { Minister.all_active }
+  describe '.active' do
+    let(:minister) { create(:minister) }
+    let(:deleted_minister) { create(:deleted_minister) }
 
     it 'returns only active ministers' do
-      expect(subject).to include(minister)
+      subject = Minister.active
+      expect(subject).to eq [minister]
     end
-    it 'includes all active ministers' do
-      expect(subject.size).to eql(1)
+
+    context 'when explicitly including a minister' do
+      let(:selected_minister) { create(:deleted_minister) }
+
+      it 'is included' do
+        subject = Minister.active(selected_minister)
+        expect(subject).to eq [selected_minister, minister]
+      end
     end
   end
 end

--- a/spec/models/pq_spec.rb
+++ b/spec/models/pq_spec.rb
@@ -46,19 +46,29 @@ describe Pq do
     end
   end
 
-  describe '#closed?' do
-    subject { pq.closed? }
+	describe '#closed?' do
+		it 'is closed when answered' do
+			subject = build(:answered_pq)
+			expect(subject.closed?).to be true
+		end
 
-    context 'for unanswered question' do
-      let(:pq) { create(:Pq) }
-      it { should be false }
-    end
+		it 'is not closed when unanswered' do
+			subject = build(:Pq)
+			expect(subject.closed?).to be false
+		end
+	end
 
-    context 'for answered question' do
-      let(:pq) { create(:answered_pq) }
-      it { should be true }
-    end
-  end
+	describe '#open?' do
+		it 'open when unanswered' do
+			subject = build(:Pq)
+		  expect(subject.open?).to be true
+		end
+
+		it 'not open when answered' do
+		  subject = build(:answered_pq)
+			expect(subject.open?).to be false
+		end
+	end
 
   it 'should set pod_waiting when users set draft_answer_received' do
     expect(newQ).to receive(:set_pod_waiting)
@@ -124,7 +134,7 @@ describe Pq do
 	describe "associations" do
 		it 'should allow minister to be set' do
 			@minister = newQ.should respond_to(:minister)
-		end		
+		end
 		it 'should allow policy minister to be set' do
 			@pminister = newQ.should respond_to(:policy_minister)
 		end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,6 +52,8 @@ RSpec.configure do |config|
     c.syntax = [:should, :expect]
   end
 
+  config.infer_spec_type_from_file_location!
+
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
     DatabaseCleaner.clean


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/81759396
- Removed brakeman from Rake (will configure it to run in travis)
- Moved controller helper methods as only used by view and simplified (using DB query)
- Moved minister/policy minister autocompletes into a partial
- Added RSpec config to automatically set the example group from the folder (needed for helper specs)
