### PR TITLE
move custom logging

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -48,15 +48,6 @@ module ParliamentaryQuestions
     config.exceptions_app = self.routes
 
 
-    # Custom Logging
-    config.log_level = :info
-    config.logstasher.enabled = true
-    config.logstasher.suppress_app_log = true
-    config.logstasher.log_level = Logger::INFO
-    config.logstasher.logger_path = "#{Rails.root}/log/logstash_#{Rails.env}.json"
-    # This line is optional, it allows you to set a custom value for the @source field of the log event
-    config.logstasher.source = 'logstasher'
-
     # Statsd
     $statsd = Statsd.new 'localhost', 8125
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -79,6 +79,13 @@ ParliamentaryQuestions::Application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
+  # Custom Logging
+  config.logstasher.enabled = true
+  config.logstasher.suppress_app_log = true
+  config.logstasher.log_level = Logger::INFO
+  config.logstasher.logger_path = "#{Rails.root}/log/logstash_#{Rails.env}.json"
+  # This line is optional, it allows you to set a custom value for the @source field of the log event
+  config.logstasher.source = 'logstasher'
 
   config.after_initialize do
     sending_host = ENV['SENDING_HOST'] || 'localhost'


### PR DESCRIPTION
to production only.

The raw format is much more familiar to Rails developers and shows everything they need.

Removed log level as info is the default in production. Info should not be set in development. Debug level is much more useful.
