### PR TITLE
Reassign to currently accepting Action Officer.

### DIFF
--- a/app/models/pq.rb
+++ b/app/models/pq.rb
@@ -62,7 +62,7 @@ class Pq < ActiveRecord::Base
   scope :accepted_in, ->(action_officers) { joins(:action_officers_pqs).where(action_officers_pqs: { response: 'accepted', action_officer_id: action_officers }) }
 
   def reassign(action_officer)
-    if action_officer.present? && action_officer_accepted != action_officer
+    if action_officer.present?
       Pq.transaction do
         ao_pq_accepted.reset
         action_officers_pqs.find_or_create_by(action_officer: action_officer).accept

--- a/spec/models/pq_spec.rb
+++ b/spec/models/pq_spec.rb
@@ -159,15 +159,6 @@ describe Pq do
 			end
 		end
 
-		context 'when reassigning to the same action officer' do
-		  it 'ignores change' do
-				subject.reassign new_action_officer
-
-				expect(subject).not_to receive(:update)
-				subject.reassign new_action_officer
-		  end
-		end
-
 		context 'when nil' do
 		  it 'ignores change' do
 				expect(subject).not_to receive(:action_officers_pqs)


### PR DESCRIPTION
Removed erroneous check excluding the ability to assign the Question's assignment to the current Action Officer