### PR TITLE
[Hotfix] Avoid setting a port in action mailer options

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,6 @@ class ApplicationController < ActionController::Base
     request = self.request
     opts = ::ActionMailer::Base.default_url_options
     opts[:host] = request.host
-    opts[:port] = request.port unless [80, 443].include?(request.port)
     protocol = /(.*):\/\//.match(request.protocol)[1] if request.protocol.ends_with?("://")
     opts[:protocol] = protocol
   end


### PR DESCRIPTION
Hot-fix to avoid a production issue whereby URLs displayed in email notifications appear with port 9180