### PR TITLE
Use minister contacts in mailers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'bootstrap-will_paginate'
-gem 'coffee-rails', '~> 4.0.0'
 gem 'devise_invitable'
 gem 'devise'
 gem 'font-awesome-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,7 +238,6 @@ DEPENDENCIES
   annotate (~> 2.6.3)
   bootstrap-will_paginate
   codeclimate-test-reporter
-  coffee-rails (~> 4.0.0)
   database_cleaner
   devise
   devise_invitable

--- a/app/workers/import_worker.rb
+++ b/app/workers/import_worker.rb
@@ -1,15 +1,3 @@
-# Sideqik Worker, more info here http://sidekiq.org/
-#
-# To run the workers:
-#   $ bundle exec sidekiq
-#
-# Dependencies:
-#
-#   You need a Redis server on -> localhost:6379
-#   or you can setup the environment variable
-#
-#     $ export REDIS_URL=redis://my_redis_server:6379
-#
 class ImportWorker
   def initialize
     @import = PQA::Import.new

--- a/lib/pqa/import.rb
+++ b/lib/pqa/import.rb
@@ -75,18 +75,20 @@ module PQA
       if !pq.valid?
         error_msgs   = pq.errors.messages
         @errors[uin] = error_msgs
-        @logger.warn "Failed to import question with uin #{uin} (errors: #{error_msgs})"
+        @logger.warn { "Failed to import question with uin #{uin} (errors: #{error_msgs})" }
       elsif pq.new_record?
         @created += 1
-        @logger.debug "Imported new record (uin: #{uin})"
+        @logger.debug { "Imported new record (uin: #{uin})" }
         pq.save
       else
         @updated += 1
-        @logger.debug "Updating record (uin: #{uin})"
+        @logger.debug { "Updating record (uin: #{uin})" }
         pq.save
       end
 
-      @logger.info "Completed import: questions downloaded #{@total}, new #{@created}, updated #{@updated}, invalid: #{@errors.size}"
+      LogStuff.tag(:import) do
+        @logger.info { "Completed import: questions downloaded #{@total}, new #{@created}, updated #{@updated}, invalid: #{@errors.size}" }
+      end
     end
   end
 end

--- a/spec/mailers/pq_accepted_mailer_spec.rb
+++ b/spec/mailers/pq_accepted_mailer_spec.rb
@@ -39,9 +39,13 @@ describe 'PQAcceptedMailer' do
       expect(mail.html_part.body).to include CGI::escape(expectedCC)
     end
 
-    it 'should set the right cc with minister the right people if the minister is Simon Hughes' do
+    it 'should cc minister contacts when present' do
+      minister_simon.minister_contacts << MinisterContact.create(email: 'bob@pq.com')
+      minister_simon.save
+
       pq = create(:pq, uin: 'HL789', question: 'test question?', minister_id: minister_simon.id, policy_minister_id: minister_2.id)
-      expectedCC = 'Christopher.Beal@justice.gsi.gov.uk;Nicola.Calderhead@justice.gsi.gov.uk;thomas.murphy@JUSTICE.gsi.gov.uk'
+      contact_emails = minister_simon.minister_contacts.map(&:email)
+      expectedCC = contact_emails.join(';')
 
       PqMailer.acceptance_email(pq, ao).deliver
 


### PR DESCRIPTION
- Delete hardcoded minister contact list and use the one built-into the app.
- minor fixes