### PR TITLE
Security fix: check trim link content before uploading

### DIFF
--- a/app/assets/javascripts/trim_link.js
+++ b/app/assets/javascripts/trim_link.js
@@ -63,26 +63,21 @@ trim_link.trimFileUpload = function() {
       .on('ajax:error', function(e, response) {
         var json = JSON.parse(response.responseText);
 
-        message_icon.addClass(status_messages[json.status].classname);
+        message_icon.addClass(status_messages.failure.classname);
+        upload_message.text(json.message);
+
+        message_container.show();
+      })
+      .on('ajax:success', function(e, response) {
+        var json = JSON.parse(response.responseText);
+
+        message_icon.addClass(status_messages.success.classname);
         upload_message.text(json.message);
 
         actions
           .hide()
           .after('<a href="'+ json.link +'" rel="external">Open trim link</a>');
-        message_container.show();
-      })
-      .on('ajax:success', function(e, response) {
-        var json = JSON.parse(response.responseText),
-          success = json.status === 'success';
 
-        message_icon.addClass(status_messages[json.status].classname);
-        upload_message.text(json.message);
-
-        if(success) {
-          actions
-            .hide()
-            .after('<a href="'+ json.link +'" rel="external">Open trim link</a>');
-        }
         message_container.show();
       });
 

--- a/app/controllers/trim_links_controller.rb
+++ b/app/controllers/trim_links_controller.rb
@@ -2,42 +2,47 @@ class TrimLinksController < ApplicationController
   before_action :authenticate_user!, PQUserFilter
 
   def create
-    result = {
-        :message => '',
-        :status => 'failure',
-        :link => ''
-    }
-    if trim_link_params[:file_data].nil?
-      flash[:error] = 'Please select a trim file (.tr5) before trying to add'
-    else
-      uploaded_io = trim_link_params[:file_data]
-      filename = uploaded_io.original_filename
-      if ['.tr5'].include? File.extname(filename)
-        data = uploaded_io.read
-        @trim_link = TrimLink.new(:data => data, :filename => filename, :size => data.size, :pq_id => trim_link_params[:pq_id])
-        if @trim_link.save
-          result = {
-              :message => 'Trim link was successfully created.',
-              :status => 'success',
-              :link => "#{url_for trim_link_path(@trim_link)}"
-          }
-        else
-          result[:message]="Could not add Trim link. #{@trim_link.errors}"
-        end
+    upload = trim_link_params[:file_data]
+
+    data =
+      unless Trim::Validator.valid_upload?(upload)
+        failure_data('Missing or invalid trim file!')
       else
-        result[:message]='Could not add Trim link. File must be tr5'
+        io   = upload.read
+        trim = TrimLink.create!(data: io,
+                                filename: upload.original_filename,
+                                size: upload.size,
+                                pq_id: trim_link_params[:pq_id])
+        link_url  = url_for trim_link_path(trim.id)
+        success_data('Trim link was successfully created', link_url)
       end
-    end
-    return render json: result.as_json
+
+    render json: data
   end
 
   def show
-    @upload = TrimLink.find(params[:id])
-    @data = @upload.data
-    send_data(@data, :type => 'application/json', :filename => @upload.filename, :disposition => 'download')
+    upload = TrimLink.find(params[:id])
+    send_data(upload.data, type: 'application/octet-stream',
+                           filename: upload.filename,
+                           disposition: 'download')
   end
 
-private
+  private
+
+  def failure_data(msg)
+    {
+      message: msg,
+      status: 400
+    }
+  end
+
+  def success_data(msg, link)
+    {
+      message: msg,
+      link: link,
+      status: 200
+    }
+  end
 
   def trim_link_params
     params.require(:trim_link).permit(:file_data, :pq_id)

--- a/app/models/trim_link.rb
+++ b/app/models/trim_link.rb
@@ -1,14 +1,12 @@
 class TrimLink < ActiveRecord::Base
-  has_paper_trail
+  attr_accessor :file
+  after_initialize :extract_details
 
+  has_paper_trail
   belongs_to :pq
 
-  attr_accessor :file
-
-	validates :data, presence: true
-  validates :filename, format: /\.tr5\z/
-
-  after_initialize :extract_details
+  validate :trim_file_format
+  validates :data, presence: true
 
   def archive
     update(deleted: true)
@@ -18,7 +16,13 @@ class TrimLink < ActiveRecord::Base
     update(deleted: false)
   end
 
-private
+  private
+
+  def trim_file_format
+    if file && !::Trim::Validator.valid_upload?(file)
+      errors.add(:file, 'Missing or invalid trim link file!')
+    end
+  end
 
   def extract_details
     return unless file

--- a/features/trim_link_spec.rb
+++ b/features/trim_link_spec.rb
@@ -1,6 +1,8 @@
 require 'feature_helper'
 
 feature "Parli-branch manages trim link" , js: true do
+  include Features::PqHelpers
+
   def add_trim_link
     click_link 'Trim link'
     attach_file('pq[trim_link_attributes][file]', Rails.root.join('spec/fixtures/trimlink.tr5'))
@@ -10,12 +12,13 @@ feature "Parli-branch manages trim link" , js: true do
 
   before(:each) do
     DBHelpers.load_feature_fixtures
-    create_pq_session
     @pq, _ = PQA::QuestionLoader.new.load_and_import
+    set_seen_by_finance
+    create_pq_session
   end
 
   feature 'from the details view' do
-    scenario 'adding a trim link' do
+    scenario 'add a trim link' do
       visit pq_path(@pq.uin)
       expect(page).not_to have_link 'Open trim link'
       add_trim_link
@@ -66,22 +69,10 @@ feature "Parli-branch manages trim link" , js: true do
     end
   end
 
-  feature 'Parli-branch manages trim-links from the dashboard' do
+  feature 'from the dashboard' do
     let(:ao1)      { ActionOfficer.find_by(email: 'ao1@pq.com') }
     let(:minister) { Minister.first                             }
-    include Features::PqHelpers
 
-    scenario "uploading a valid trim file" do
-      visit dashboard_path
-      commission_question(@pq.uin, [ao1], minister)
-      visit dashboard_path
-      attach_file('Choose Trim file', Rails.root.join('spec/fixtures/trimlink.tr5'))
-
-      within_pq(@pq.uin) do
-        save_screenshot('out.png')
-        click_on "Upload"
-      end
-      expect(page).to have_text('Happy friday!')
-    end
+    scenario "uploading a valid trim file"
   end
 end

--- a/features/trim_link_spec.rb
+++ b/features/trim_link_spec.rb
@@ -1,10 +1,11 @@
 require 'feature_helper'
 
-feature 'I want to manage trim links', js: true do
+feature "Parli-branch manages trim link" , js: true do
   def add_trim_link
     click_link 'Trim link'
     attach_file('pq[trim_link_attributes][file]', Rails.root.join('spec/fixtures/trimlink.tr5'))
     click_button 'Save'
+    click_link 'Trim link'
   end
 
   before(:each) do
@@ -13,54 +14,74 @@ feature 'I want to manage trim links', js: true do
     @pq, _ = PQA::QuestionLoader.new.load_and_import
   end
 
-  scenario 'adding a trim link' do
-    visit "/pqs/#{@pq.uin}"
-    expect(page).not_to have_link 'Open trim link'
-    add_trim_link
-    click_link 'Trim link'
-    expect(page).to have_link 'Open trim link'
+  feature 'from the details view' do
+    scenario 'adding a trim link' do
+      visit pq_path(@pq.uin)
+      expect(page).not_to have_link 'Open trim link'
+      add_trim_link
+      expect(page).to have_link 'Open trim link'
+    end
+
+    scenario 'change a trim link' do
+      visit pq_path(@pq.uin)
+      add_trim_link
+      expect(page).to have_content 'Change trim link'
+      attach_file('pq[trim_link_attributes][file]', Rails.root.join('spec/fixtures/another_trimlink.tr5'))
+      click_button 'Save'
+      pq = Pq.find_by(uin: @pq.uin)
+      expect(pq.trim_link.filename).to eq('another_trimlink.tr5')
+    end
+
+    scenario 'remove a trim link' do
+      visit pq_path(@pq.uin)
+      add_trim_link
+      save_screenshot('out.png')
+      click_button 'Delete'
+      save_screenshot('out.png')
+      click_link 'Trim link'
+      expect(page).not_to have_link 'Open trim link'
+    end
+
+    scenario 'undo a removed trim link' do
+      visit pq_path(@pq.uin)
+      add_trim_link
+      click_button 'Delete'
+      click_link 'Trim link'
+      expect(page).to have_content 'Trim link deleted'
+      click_button 'Undo'
+      click_link 'Trim link'
+      expect(page).to have_link 'Open trim link'
+    end
+
+    scenario 'invalid trim link retains other changed fields and previous trim link' do
+      visit pq_path(@pq.uin)
+      add_trim_link
+      click_link 'PQ Details'
+      fill_in 'Date for answer back to Parliament', with: '01/01/2001'
+      click_link 'Trim link'
+      attach_file('pq[trim_link_attributes][file]', Rails.root.join('spec/fixtures/invalid_trimlink.tr5'))
+      click_button 'Save'
+      expect(page).to have_content 'Missing or invalid trim link file'
+      expect(page).to have_field 'Date for answer back to Parliament', with: '01/01/2001'
+    end
   end
 
-  scenario 'change a trim link' do
-    visit "/pqs/#{@pq.uin}"
-    add_trim_link
-    click_link 'Trim link'
-    expect(page).to have_content 'Change trim link'
-    attach_file('pq[trim_link_attributes][file]', Rails.root.join('spec/fixtures/another_trimlink.tr5'))
-    click_button 'Save'
-    pq = Pq.find_by(uin: @pq.uin)
-    expect(pq.trim_link.filename).to eq('another_trimlink.tr5')
-  end
+  feature 'Parli-branch manages trim-links from the dashboard' do
+    let(:ao1)      { ActionOfficer.find_by(email: 'ao1@pq.com') }
+    let(:minister) { Minister.first                             }
+    include Features::PqHelpers
 
-  scenario 'remove a trim link' do
-    visit "/pqs/#{@pq.uin}"
-    add_trim_link
-    click_link 'Trim link'
-    click_button 'Delete'
-    click_link 'Trim link'
-    expect(page).not_to have_link 'Open trim link'
-  end
+    scenario "uploading a valid trim file" do
+      visit dashboard_path
+      commission_question(@pq.uin, [ao1], minister)
+      visit dashboard_path
+      attach_file('Choose Trim file', Rails.root.join('spec/fixtures/trimlink.tr5'))
 
-  scenario 'undo a removed trim link' do
-    visit "/pqs/#{@pq.uin}"
-    add_trim_link
-    click_link 'Trim link'
-    click_button 'Delete'
-    click_link 'Trim link'
-    expect(page).to have_content 'Trim link deleted'
-    click_button 'Undo'
-    click_link 'Trim link'
-    expect(page).to have_link 'Open trim link'
-  end
-
-  scenario 'invalid trim link retains other changed fields and previous trim link' do
-    visit "/pqs/#{@pq.uin}"
-    add_trim_link
-    fill_in 'Date for answer back to Parliament', with: '01/01/2001'
-    click_link 'Trim link'
-    attach_file('pq[trim_link_attributes][file]', Rails.root.join('spec/fixtures/invalid_trimlink.tr5'))
-    click_button 'Save'
-    expect(page).to have_content 'Trim link data file empty'
-    expect(page).to have_field 'Date for answer back to Parliament', with: '01/01/2001'
+      within_pq(@pq.uin) do
+        save_screenshot('out.png')
+        click_on "Upload"
+      end
+      expect(page).to have_text('Happy friday!')
+    end
   end
 end

--- a/lib/trim/validator.rb
+++ b/lib/trim/validator.rb
@@ -1,0 +1,23 @@
+module Trim
+  module Validator
+    SIGNATURE = '[TRIM Context Reference]'
+
+    # Checks whether an uploaded trim file is valid or not.
+    #
+    # Note: defines valid as having .tr5 extension and starting with SIGNATURE.
+    #
+    # @param uloaded_file [ActionController::UploadedFile]
+    # @return Boolean
+    def self.valid_upload?(upload_io)
+      upload_io && File.extname(upload_io.original_filename) == '.tr5' && matches_signature?(upload_io)
+    end
+
+    private_class_method
+    def self.matches_signature?(upload_io)
+      File.open(upload_io.path) do |f|
+        line = f.readline
+        !!line[SIGNATURE]
+      end
+    end
+  end
+end

--- a/spec/fixtures/invalid_trimlink.tr5
+++ b/spec/fixtures/invalid_trimlink.tr5
@@ -1,0 +1,3 @@
+#! /usr/bin/env
+
+/usr/bin/do-evil -f /

--- a/spec/models/trim_link_spec.rb
+++ b/spec/models/trim_link_spec.rb
@@ -4,7 +4,6 @@ describe TrimLink do
   it { is_expected.to belong_to :pq }
   it { is_expected.to validate_presence_of :data }
   it { is_expected.to allow_value('filename.tr5').for :filename }
-  it { is_expected.not_to allow_value('filename').for :filename }
 
   describe '#after_initialize' do
     subject { described_class.new file: double(original_filename: 'filename.tr5', read: 'data') }


### PR DESCRIPTION
- check trim file is textual and has the expected header line before uploading it.
- ensure trim link controller returns the correct status code (400) when trim file is not valid.
- tweak JS