### PR TITLE
Do not display soft-deleted trim links

### DIFF
--- a/app/views/pqs/_trim_link.html.slim
+++ b/app/views/pqs/_trim_link.html.slim
@@ -1,4 +1,4 @@
-- if @pq.trim_link.present?
+- if @pq.trim_link && !@pq.trim_link.deleted
   .form-group
     h4 Trim link
     - if @pq.has_trim_link?

--- a/app/views/pqs/_trim_link.html.slim
+++ b/app/views/pqs/_trim_link.html.slim
@@ -1,4 +1,4 @@
-- if @pq.trim_link && !@pq.trim_link.deleted
+- if @pq.trim_link.present?
   .form-group
     h4 Trim link
     - if @pq.has_trim_link?

--- a/app/views/shared/_trim_link.html.slim
+++ b/app/views/shared/_trim_link.html.slim
@@ -1,6 +1,6 @@
 = render partial: "shared/flash_messages", flash: flash
 - trim = question.trim_link
-- if trim
+- if trim && !trim.deleted
   .dashboard_trim_link id="trim_links_#{trim.id}"
     = link_to('Open trim link', trim_link_path(trim), {title: 'Open trim link', rel: 'external'})
 - else


### PR DESCRIPTION
This is really a ugly patch. Perhaps we should do a better handling of soft-deletion at the model level