### PR TITLE
HOTFIX: Update docker config to use at least 4 unicorn workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,12 @@ SMTP_PORT=<port>
 SMTP_USERNAME=
 SMTP_PASSWORD=
 
-# for production only
+# FOR PRODUCTION ONLY...
+
+# Path to ssl certs
 CA_CERT=/etc/ssl/certs/
+# number of unicorn workers
+ENV["WEB_CONCURRENCY"]=4
 
 # host to deploy the assets (following the assets pipeline)
 ASSET_HOST=http://assets.example.com

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ SMTP_PASSWORD=
 # Path to ssl certs
 CA_CERT=/etc/ssl/certs/
 # number of unicorn workers
-ENV["WEB_CONCURRENCY"]=4
+WEB_CONCURRENCY=4
 
 # host to deploy the assets (following the assets pipeline)
 ASSET_HOST=http://assets.example.com

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,22 +1,10 @@
-worker_processes 4
+n = Integer(ENV["WEB_CONCURRENCY"] || 4)
+worker_processes(n)
 
-rails_env = 'production'
-app_home = ENV['APP_HOME'] || '/home/vagrant/pq/current'
-
-#listen "/home/vagrant/pq/shared/unicorn.sock", :backlog => 64
-listen 3000
-working_directory "#{app_home}"
-pid "#{app_home}/log/unicorn.pid"
-stderr_path "#{app_home}/log/unicorn.stderr.log"
-stdout_path "#{app_home}/log/unicorn.stdout.log"
-
-timeout 30
-preload_app true
-
-before_fork do |server, worker|
+before_fork do |_, _|
   defined?(ActiveRecord::Base) and ActiveRecord::Base.connection.disconnect!
 end
 
-after_fork do |server, worker|
+after_fork do |_, _|
   defined?(ActiveRecord::Base) and ActiveRecord::Base.establish_connection
 end

--- a/docker/rails/unicorn.service
+++ b/docker/rails/unicorn.service
@@ -44,5 +44,5 @@ fi
 echo "restart.rails:1|s" | nc.traditional -w 1 -u 127.0.0.1 8125
 
 echo "Starting unicorn"           >>/rails/log/unicorn.log
-exec bundle exec unicorn -p 80    >>/rails/log/unicorn.log 2>&1
+exec bundle exec unicorn -p 80 -c config/unicorn.rb  >>/rails/log/unicorn.log 2>&1
 


### PR DESCRIPTION
unicorn.service was not explicitly setting the config file, hence spawning only 1 worker process (we default to 4 now)