### PR TITLE
Bugfix: Sticky minister fields

### DIFF
--- a/app/controllers/pqs_controller.rb
+++ b/app/controllers/pqs_controller.rb
@@ -16,7 +16,7 @@ class PqsController < ApplicationController
       with_valid_dates do
         archive_trim_link!(params[:commit])
 
-        if @pq.update(pq_params) 
+        if @pq.update(pq_params)
           PQProgressChangerService.new.update_progress(@pq)
           reassign_ao_if_present(@pq)
           flash[:success] = 'Successfully updated'

--- a/app/views/dashboard/_question_data_uncommissioned.html.slim
+++ b/app/views/dashboard/_question_data_uncommissioned.html.slim
@@ -1,5 +1,5 @@
 .pq-columns.row
-  = form_for CommissionForm.new,
+  = form_for CommissionForm.new(minister_id: question.minister_id, policy_minister_id: question.policy_minister_id),
   remote: true,
   authenticity_token: true,
   html: {:id => "form-commission#{question.id}", :class => 'form-commission', :data => {pqid: question.id}},

--- a/features/rejecting_aos_spec.rb
+++ b/features/rejecting_aos_spec.rb
@@ -15,13 +15,18 @@ feature 'Parli-branch manually rejecting and re-assigning OAs', js: true, suspen
     DatabaseCleaner.clean
   end
 
-  let(:ao1)        { ActionOfficer.find_by(email: 'ao1@pq.com') }
-  let(:ao2)        { ActionOfficer.find_by(email: 'ao2@pq.com') }
-  let(:ao3)        { ActionOfficer.find_by(email: 'ao3@pq.com') }
-  let(:minister)   { Minister.first                             }
+  let(:ao1)             { ActionOfficer.find_by(email: 'ao1@pq.com') }
+  let(:ao2)             { ActionOfficer.find_by(email: 'ao2@pq.com') }
+  let(:ao3)             { ActionOfficer.find_by(email: 'ao3@pq.com') }
+  let(:minister)        { Minister.first                             }
+  let(:policy_minister) { Minister.limit(2)[1]                       }
+
+  def selected_option_text(field_name)
+    find("select[name='#{field_name}'] option[selected='selected']").text
+  end
 
   scenario "PB commissions a question to two AOs" do
-    commission_question(@pq.uin, [ao1, ao2], minister)
+    commission_question(@pq.uin, [ao1, ao2], minister, policy_minister)
   end
 
   scenario "PB manually rejects the first AO" do
@@ -43,7 +48,13 @@ feature 'Parli-branch manually rejecting and re-assigning OAs', js: true, suspen
     visit pq_path(@pq.uin)
     click_on "PQ commission"
     first('a', text:'Manually reject this action officer').click
-    
     expect_pq_status(@pq.uin, "Rejected")
+
+    within_pq(@pq.uin) do
+      selected_minister        = selected_option_text('commission_form[minister_id]')
+      selected_policy_minister = selected_option_text('commission_form[policy_minister_id]')
+      expect(selected_minister).to eq(minister.name)
+      expect(selected_policy_minister).to eq(policy_minister.name)
+    end
   end
 end

--- a/spec/support/features/pq_helpers.rb
+++ b/spec/support/features/pq_helpers.rb
@@ -7,12 +7,13 @@ module Features
       click_link_or_button 'btn_finance_visibility'
     end
 
-    def commission_question(uin, action_officers, minister)
+    def commission_question(uin, action_officers, minister, policy_minister = nil)
       create_pq_session
       visit dashboard_path
 
       within_pq(uin) do
-        select minister.name, from: 'Answering minister'
+        select_option('commission_form[minister_id]', minister.name)
+        select_option('commission_form[policy_minister_id]', policy_minister.name) if policy_minister
 
         action_officers.each do |ao|
           select ao.name, from: 'Action officer(s)'
@@ -68,6 +69,12 @@ module Features
     end
 
     private
+
+    def select_option(selector_name, option_text)
+      find(:select, selector_name)
+            .find(:option, text: option_text)
+            .select_option
+    end
 
     def visit_assignment_url(action_officer)
       mail = sent_mail_to(action_officer.email).first


### PR DESCRIPTION
Make sure that selected minister and policy minister values persist even after the PQ gets manually re-commissioned