### PR TITLE
display specialised error page if expired token

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem "select2-rails"
 
 group :development do
   gem 'annotate', '~> 2.6.3'
+  gem 'awesome_print'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,7 @@ GEM
       activerecord (>= 2.3.0)
       rake (>= 0.8.7)
     arel (5.0.1.20140414130214)
+    awesome_print (1.6.1)
     bcrypt (3.1.7)
     bootstrap-will_paginate (0.0.10)
       momentjs-rails (~> 2.5.0)
@@ -233,6 +234,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate (~> 2.6.3)
+  awesome_print
   bootstrap-will_paginate
   codeclimate-test-reporter
   database_cleaner

--- a/app/controllers/ao_token_filter.rb
+++ b/app/controllers/ao_token_filter.rb
@@ -1,7 +1,7 @@
 class AOTokenFilter
   def self.before(controller)
     if !has_access(controller)
-      controller.render :file => "public/401.html", :status => :unauthorized
+      controller.render :file => "shared/token_expired.html.slim", :status => :unauthorized
     end
   end
 

--- a/app/views/shared/token_expired.html.slim
+++ b/app/views/shared/token_expired.html.slim
@@ -1,0 +1,8 @@
+p.br.space-before-20
+  strong Access Token expired
+
+p.br.space-before
+  | The time allocated for you to accept or reject this question has expired.  Please 
+  a href="mailto:#{Settings.mail_reply_to}"  contact the PQ team
+  | &nbsp;to get the question reassigned.
+

--- a/features/commision_question_spec.rb
+++ b/features/commision_question_spec.rb
@@ -76,6 +76,6 @@ feature 'Commissioning questions', js: true, suspend_cleaner: true do
     url = extract_url_like('/assignment', ao_mail)
     visit url
 
-    expect(page).to have_content(/you don't have permission to see the page/i)
+    expect(page).to have_content(/Access Token expired/i)
   end
 end

--- a/features/watch_list_spec.rb
+++ b/features/watch_list_spec.rb
@@ -54,7 +54,7 @@ feature "Watch list member sees allocated questions", suspend_cleaner: true do
     url = extract_url_like(watchlist_dashboard_path, sent_mail.last)
     visit url
 
-    expect(page).to have_text(/unauthorized/i)
+    expect(page).to have_text(/Access Token expired/i)
   end
 
   private


### PR DESCRIPTION
display specialised error page if expired token is used to by AO to action PQ or access watch list