### PR TITLE
Simplify sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The Postgresql version used in production is 9.3. This can be installed via [hom
 
 Install the app dependencies by running the following
 
-		gem install bundler && bundle install
+    gem install bundler && bundle install
 
 If you get problems installing the pg gem not being able to find libpg, try setting the architecture flag as follows:
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -55,8 +55,6 @@ class DashboardController < ApplicationController
 
   def paginate_collection(pqs)
     page = params.fetch(:page, 1)
-    pqs.paginate(page: page, per_page: PER_PAGE)
-      .order("date_for_answer_has_passed asc, days_from_date_for_answer asc, progress_id desc, updated_at asc")
-      .load
+    pqs.sorted_for_dashboard.paginate(page: page, per_page: PER_PAGE)
   end
 end

--- a/app/models/pq.rb
+++ b/app/models/pq.rb
@@ -59,7 +59,7 @@ class Pq < ActiveRecord::Base
   ]
   validates :final_response_info_released, inclusion: RESPONSES, allow_nil: true
 
-  before_update :set_pod_waiting, :process_date_for_answer, :set_state_weight
+  before_update :set_pod_waiting, :set_state_weight
 
   def set_pod_waiting
     self.pod_waiting = draft_answer_received if draft_answer_received_changed?
@@ -72,16 +72,6 @@ class Pq < ActiveRecord::Base
   def update_state!
     self.state = PQState.progress_changer.next_state(PQState::UNASSIGNED, self)
     self.save!
-  end
-
-  def process_date_for_answer
-    unless date_for_answer
-      self.date_for_answer_has_passed = true
-      self.days_from_date_for_answer = LARGEST_POSTGRES_INTEGER
-    else
-      self.date_for_answer_has_passed = self.date_for_answer < Date.today
-      self.days_from_date_for_answer = (self.date_for_answer - Date.today).abs
-    end
   end
 
   def reassign(action_officer)

--- a/app/models/pq_counts.rb
+++ b/app/models/pq_counts.rb
@@ -59,7 +59,7 @@ module PqCounts
                      .reduce({}) { |acc, r| acc.merge(r.state => r.count) }
 
     state_counts.merge({
-      'view_all'             => Pq.count,
+      'view_all'             => Pq.new_questions.count,
       'view_all_in_progress' => Pq.in_progress.count,
       'transferred_in'       => Pq.transferred.count,
       'iww'                  => Pq.i_will_write_flag.count

--- a/app/models/pq_scopes.rb
+++ b/app/models/pq_scopes.rb
@@ -26,10 +26,9 @@ module PqScopes
   end
 
   def sorted_for_dashboard
-    order("date_for_answer > CURRENT_DATE ASC")
-      .order("ABS(DATE_PART('day', date_for_answer::timestamp - CURRENT_DATE::timestamp)) ASC")
+    order("DATE_PART('day', date_for_answer::timestamp - CURRENT_DATE::timestamp) ASC")
       .order('state_weight DESC')
-      .order('updated_at ASC')
+      .order('updated_at ASC') # <= This ASC causes the weird effect of pushing recent edits to the bottom of the list
   end
 
   def new_questions

--- a/app/models/pq_scopes.rb
+++ b/app/models/pq_scopes.rb
@@ -25,6 +25,13 @@ module PqScopes
       .where("aopq.response = 'accepted' AND pd.deleted = false")
   end
 
+  def sorted_for_dashboard
+    order("date_for_answer > CURRENT_DATE ASC")
+      .order("ABS(DATE_PART('day', date_for_answer::timestamp - CURRENT_DATE::timestamp)) ASC")
+      .order('state_weight DESC')
+      .order('updated_at ASC')
+  end
+
   def new_questions
     by_status(PQState::NEW)
   end
@@ -92,11 +99,4 @@ module PqScopes
   def i_will_write_flag
     where('i_will_write = true AND state NOT IN (?)', PQState::CLOSED)
   end
-
-  #def sorted_for_dashboard
-  #  order("date_for_answer > CURRENT_DATE ASC")
-  #    .order("DATE_PART('day', date_for_answer::timestamp - CURRENT_DATE::timestamp) ASC")
-  #    .order('state_weight DESC')
-  #    .order('updated_at ASC')
-  #end
 end

--- a/db/migrate/20150331154333_remove_sorting_related_columns.rb
+++ b/db/migrate/20150331154333_remove_sorting_related_columns.rb
@@ -1,0 +1,17 @@
+class RemoveSortingRelatedColumns < ActiveRecord::Migration
+  def up
+    remove_column(:pqs, :date_for_answer_has_passed)
+    remove_column(:pqs, :days_from_date_for_answer)
+
+    add_index(:pqs, :date_for_answer)
+    execute "CREATE INDEX days_from_date_for_answer ON pqs (DATE_PART('day', date_for_answer::timestamp))"
+    add_index(:pqs, :state_weight)
+    add_index(:pqs, :updated_at)
+    add_index(:pqs, :internal_deadline)
+    add_index(:pqs, :state)
+    add_index(:pqs, :minister_id)
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150325143021) do
+ActiveRecord::Schema.define(version: 20150331154333) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -167,12 +167,17 @@ ActiveRecord::Schema.define(version: 20150325143021) do
     t.integer  "division_id"
     t.integer  "transfer_in_ogd_id"
     t.datetime "transfer_in_date"
-    t.integer  "days_from_date_for_answer"
-    t.boolean  "date_for_answer_has_passed"
     t.string   "follow_up_to"
     t.string   "state",                                         default: "unassigned"
     t.integer  "state_weight",                                  default: 0
   end
+
+  add_index "pqs", ["date_for_answer"], name: "index_pqs_on_date_for_answer", using: :btree
+  add_index "pqs", ["internal_deadline"], name: "index_pqs_on_internal_deadline", using: :btree
+  add_index "pqs", ["minister_id"], name: "index_pqs_on_minister_id", using: :btree
+  add_index "pqs", ["state"], name: "index_pqs_on_state", using: :btree
+  add_index "pqs", ["state_weight"], name: "index_pqs_on_state_weight", using: :btree
+  add_index "pqs", ["updated_at"], name: "index_pqs_on_updated_at", using: :btree
 
   create_table "press_desks", force: true do |t|
     t.string   "name"

--- a/features/import_spec.rb
+++ b/features/import_spec.rb
@@ -94,7 +94,7 @@ describe PQA::Import do
         pq = Pq.find_by(uin: 'uin-1')
         pq.update(state: PQState::REJECTED)
 
-        expect(Pq.order(:uin).map {|pq|
+        expect(Pq.order(:uin).map { |pq|
           d      = pq.tabled_date
           state  = pq.state
 
@@ -104,21 +104,6 @@ describe PQA::Import do
           ['uin-1', [3, 2, 2015], PQState::REJECTED],
           ['uin-2', [4, 2, 2015], PQState::UNASSIGNED]
         ])
-      end
-
-      context "when some the 'date_for_answer' of some question has expired" do
-        before do
-          allow(Date).to receive(:today) { Date.parse('5/2/2015') }
-          import.run(from_date, to_date)
-        end
-
-        it "flags questions for which the date for answer has passed" do
-          expect(Pq.order(:uin).pluck(:uin, :date_for_answer_has_passed)).to eq([
-            ['uin-0', true],
-            ['uin-1', true],
-            ['uin-2', false]
-          ])
-        end
       end
     end
   end

--- a/lib/pqa/import.rb
+++ b/lib/pqa/import.rb
@@ -16,7 +16,6 @@ module PQA
         questions.each do |q|
           insert_or_update(q)
         end
-        update_sort_dates
       end
       report
     end
@@ -39,7 +38,6 @@ module PQA
       }
     end
 
-    def update_sort_dates
       Pq.find_each(batch_size: 100) do |pq|
         unless pq.date_for_answer
           pq.date_for_answer_has_passed = true

--- a/lib/pqa/import.rb
+++ b/lib/pqa/import.rb
@@ -38,18 +38,6 @@ module PQA
       }
     end
 
-      Pq.find_each(batch_size: 100) do |pq|
-        unless pq.date_for_answer
-          pq.date_for_answer_has_passed = true
-          pq.days_from_date_for_answer = LARGEST_POSTGRES_INTEGER
-        else
-          pq.date_for_answer_has_passed = pq.date_for_answer < Date.today
-          pq.days_from_date_for_answer = (pq.date_for_answer - Date.today).abs
-        end
-        pq.save
-      end
-    end
-
     def insert_or_update(q)
       uin = q.uin
       pq  = Pq.find_or_initialize_by(uin: uin)

--- a/spec/models/pq_spec.rb
+++ b/spec/models/pq_spec.rb
@@ -20,6 +20,28 @@ describe Pq do
     end
   end
 
+  describe ".sorted_for_dashboard" do
+    before do
+        @pq1, @pq2, @pq3, @pq4, @pq5 = DBHelpers.pqs(5)
+        @pq2.update(date_for_answer: Date.yesterday)
+        @pq1.update(updated_at: Date.yesterday, state: PQState::POD_CLEARED,
+                    date_for_answer: Date.tomorrow + 1.days)
+        @pq4.update(state: PQState::POD_CLEARED, date_for_answer: Date.tomorrow + 1.days)
+        @pq5.update(date_for_answer: Date.tomorrow + 1.days)
+        @pq3.update(date_for_answer: Date.tomorrow + 2.days)
+    end
+
+    it "sorts pqs in the expected order" do
+      expect(Pq.sorted_for_dashboard.map(&:uin)).to eq([
+        @pq2,
+        @pq1,
+        @pq4,
+        @pq5,
+        @pq3
+      ].map(&:uin))
+    end
+  end
+
   describe ".count_accepted_by_press_desk" do
     def accept_pq(pq, ao)
       pq.action_officers_pqs << ActionOfficersPq.new(action_officer: ao,

--- a/spec/models/pq_spec.rb
+++ b/spec/models/pq_spec.rb
@@ -22,13 +22,13 @@ describe Pq do
 
   describe ".sorted_for_dashboard" do
     before do
-        @pq1, @pq2, @pq3, @pq4, @pq5 = DBHelpers.pqs(5)
-        @pq2.update(date_for_answer: Date.yesterday)
-        @pq1.update(updated_at: Date.yesterday, state: PQState::POD_CLEARED,
-                    date_for_answer: Date.tomorrow + 1.days)
-        @pq4.update(state: PQState::POD_CLEARED, date_for_answer: Date.tomorrow + 1.days)
-        @pq5.update(date_for_answer: Date.tomorrow + 1.days)
-        @pq3.update(date_for_answer: Date.tomorrow + 2.days)
+      @pq1, @pq2, @pq3, @pq4, @pq5 = DBHelpers.pqs(5)
+      @pq2.update(date_for_answer: Date.yesterday)
+      @pq1.update(updated_at: Date.yesterday, state: PQState::POD_CLEARED,
+                  date_for_answer: Date.tomorrow + 1.days)
+      @pq4.update(state: PQState::POD_CLEARED, date_for_answer: Date.tomorrow + 1.days)
+      @pq5.update(date_for_answer: Date.tomorrow + 1.days)
+      @pq3.update(date_for_answer: Date.tomorrow + 2.days)
     end
 
     it "sorts pqs in the expected order" do

--- a/spec/support/db_helpers.rb
+++ b/spec/support/db_helpers.rb
@@ -46,8 +46,8 @@ module DBHelpers
     end
   end
 
-  def pqs
-    (1..4).map do |n|
+  def pqs(n=4)
+    (1..n).map do |n|
       Pq.find_or_create_by(
         uin: "uin-#{n}",
         house_id: 1,


### PR DESCRIPTION
Fully decouple the dashboard sorting functionality from the import module. This implementation uses Postgres `DATE_PART` function to compute the `days_from_date_for_answer` at run-time. We also got rid of the `date_for_answer_has_passed` column. Expired PQs are still listed first for their timestamp delta value will be negative, and we are sorting in ascending order. 