### PR TITLE
Deploy branch

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,15 +5,13 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_filter :configure_permitted_parameters, if: :devise_controller?
 
-  # if Rails.env.production? || Rails.env.test?
-    rescue_from StandardError do |exception|
-      if exception.is_a?(ActiveRecord::RecordNotFound)
-        page_not_found(exception)
-      else
-        server_error(exception)
-      end
+  rescue_from StandardError do |exception|
+    if exception.is_a?(ActiveRecord::RecordNotFound)
+      page_not_found(exception)
+    else
+      server_error(exception)
     end
-  # end
+  end
 
   def set_am_host
     request = self.request

--- a/app/models/pq.rb
+++ b/app/models/pq.rb
@@ -69,6 +69,9 @@
 #
 
 class Pq < ActiveRecord::Base
+
+  belongs_to :progress
+
   has_paper_trail
 
   include PqFollowup

--- a/app/models/pq.rb
+++ b/app/models/pq.rb
@@ -127,7 +127,7 @@ class Pq < ActiveRecord::Base
     "Partial Disproportionate cost",
     "Referral"
   ]
-  validates :final_response_info_released, inclusion: RESPONSES, allow_nil: true
+  validates :final_response_info_released, inclusion: RESPONSES, allow_nil: true, allow_blank: true
 
   before_update :set_pod_waiting, :set_state_weight
 


### PR DESCRIPTION
We're unable to run the migration 20150325143021_remove_progress.rb without the belongs_to :progress relation still in the Pq model, so this put it back in temporarily.