### PR TITLE
Fix to allow prod migrations to run

### DIFF
--- a/app/models/pq.rb
+++ b/app/models/pq.rb
@@ -69,6 +69,9 @@
 #
 
 class Pq < ActiveRecord::Base
+
+  belongs_to :progress
+
   has_paper_trail
 
   include PqFollowup


### PR DESCRIPTION


Unable to do migration 20150325143021_remove_progress.rb without the progress relation still being available in Pq, so this adds it back in temporarily