### PR TITLE
Deploy fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 .idea
 .project
 .rvmrc
+postgres.log
+brakeman-output.tabs
 coverage
 log
 public/assets

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 .idea
 .project
 .rvmrc
+brakeman-output.tabs
+postgres.log
 coverage
 log
 public/assets

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,6 @@
 .idea
 .project
 .rvmrc
-postgres.log
-brakeman-output.tabs
 coverage
 log
 public/assets

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
     users_path
   end
 
-  def page_not_found(exception = nil)
+  def page_not_found(exception)
     update_page_title 'Not found (404)'
     show_error_page_and_increment_statsd(404, exception)
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
     users_path
   end
 
-  def page_not_found(exception)
+  def page_not_found(exception = nil)
     update_page_title 'Not found (404)'
     show_error_page_and_increment_statsd(404, exception)
   end


### PR DESCRIPTION
- allow ApplicationController#page_not_found to be called without params (needed for default route)
- add postgres.log and brakeman-output.tabs to .gitignore