### PR TITLE
Remove deputy directors email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ tmp
 *.swp
 *.swo
 .tern-port
+vendor

--- a/app/mailers/pq_mailer.rb
+++ b/app/mailers/pq_mailer.rb
@@ -6,15 +6,6 @@ class PqMailer < PQBaseMailer
     )
   end
 
-=begin
-  def notify_dd_email(mail_data)
-    mail_with_subject(
-      "#{mail_data.params[:ao_name]} has been allocated PQ #{mail_data.params[:uin]}",
-      mail_data
-    )
-  end
-=end
-
   def acceptance_email(mail_data)
     mail_with_subject("You accepted PQ #{mail_data.params[:uin]}", mail_data)
   end

--- a/app/mailers/pq_mailer.rb
+++ b/app/mailers/pq_mailer.rb
@@ -1,17 +1,19 @@
 class PqMailer < PQBaseMailer
   def commission_email(mail_data)
     mail_with_subject(
-      "You have been allocated PQ #{mail_data.params[:uin]}", 
+      "You have been allocated PQ #{mail_data.params[:uin]}",
       mail_data
     )
   end
 
+=begin
   def notify_dd_email(mail_data)
     mail_with_subject(
-      "#{mail_data.params[:ao_name]} has been allocated PQ #{mail_data.params[:uin]}", 
+      "#{mail_data.params[:ao_name]} has been allocated PQ #{mail_data.params[:uin]}",
       mail_data
     )
   end
+=end
 
   def acceptance_email(mail_data)
     mail_with_subject("You accepted PQ #{mail_data.params[:uin]}", mail_data)
@@ -19,14 +21,14 @@ class PqMailer < PQBaseMailer
 
   def acceptance_reminder_email(mail_data)
     mail_with_subject(
-      "URGENT REMINDER: you need to accept or reject PQ #{mail_data.params[:uin]}", 
+      "URGENT REMINDER: you need to accept or reject PQ #{mail_data.params[:uin]}",
       mail_data
     )
   end
 
   def draft_reminder_email(mail_data)
     mail_with_subject(
-      "URGENT REMINDER: please send your draft response to PQ #{mail_data.params[:uin]}", 
+      "URGENT REMINDER: please send your draft response to PQ #{mail_data.params[:uin]}",
       mail_data
     )
   end
@@ -41,7 +43,7 @@ class PqMailer < PQBaseMailer
     @template_params = mail_data.params
 
     mail(
-      mail_data.addressees.merge({ 
+      mail_data.addressees.merge({
         subject:  subject
       })
     )

--- a/app/services/commissioning_service.rb
+++ b/app/services/commissioning_service.rb
@@ -60,23 +60,6 @@ class CommissioningService
 
       MailService::Pq.commission_email(mail_params)
     end
-
-=begin
-    if dd && dd.email.present?
-      internal_deadline = pq.internal_deadline ? pq.internal_deadline.to_s(:date) :
-                                                'No deadline set'
-
-      LogStuff.tag(:mail_notify) do
-        mail_params =
-          Presenters::Email.default_hash(pq, ao).merge(
-            email: dd.email,
-            dd_name: dd.name,
-            internal_deadline: internal_deadline
-          )
-
-        MailService::Pq.notify_dd_email(mail_params)
-      end
-    end
-=end
+    
   end
 end

--- a/app/services/commissioning_service.rb
+++ b/app/services/commissioning_service.rb
@@ -52,7 +52,7 @@ class CommissioningService
     $statsd.increment "#{StatsHelper::TOKENS_GENERATE}.commission"
 
     LogStuff.tag(:mailer_commission) do
-      mail_params = 
+      mail_params =
         Presenters::Email.default_hash(pq, ao).merge(
           token: token,
           entity: entity
@@ -61,12 +61,13 @@ class CommissioningService
       MailService::Pq.commission_email(mail_params)
     end
 
+=begin
     if dd && dd.email.present?
       internal_deadline = pq.internal_deadline ? pq.internal_deadline.to_s(:date) :
                                                 'No deadline set'
 
       LogStuff.tag(:mail_notify) do
-        mail_params = 
+        mail_params =
           Presenters::Email.default_hash(pq, ao).merge(
             email: dd.email,
             dd_name: dd.name,
@@ -76,5 +77,6 @@ class CommissioningService
         MailService::Pq.notify_dd_email(mail_params)
       end
     end
+=end
   end
 end

--- a/features/commision_question_spec.rb
+++ b/features/commision_question_spec.rb
@@ -22,14 +22,12 @@ feature 'Commissioning questions', js: true, suspend_cleaner: true do
     commission_question(@pq.uin, [ao, ao2], minister)
   end
 
-  scenario 'AO and DD should receive an email notification of assigned question' do
-    ao_mail, dd_mail = sent_mail.first(2)
+  scenario 'AO should receive an email notification of assigned question' do
+    ao_mail = sent_mail.first
 
     expect(ao_mail.to).to include ao.email
     expect(ao_mail.text_part.body).to include "you have been allocated PQ #{@pq.uin}"
 
-    expect(dd_mail.to).to include ao.deputy_director.email
-    expect(dd_mail.text_part.body).to include "#{ao.name} has been allocated the PQ #{@pq.uin}"
   end
 
   scenario 'Following the email link should let the AO accept the question' do
@@ -75,7 +73,7 @@ feature 'Commissioning questions', js: true, suspend_cleaner: true do
     }
     form = CommissionForm.new(form_params)
     CommissioningService.new(nil, Date.today - 4.days).commission(form)
-    ao_mail, _ = sent_mail.last(2)
+    ao_mail, _ = sent_mail.last
     url = extract_url_like('/assignment', ao_mail)
     visit url
     expect(page.title).to have_content("Unauthorised (401)")

--- a/spec/services/commissioning_service_spec.rb
+++ b/spec/services/commissioning_service_spec.rb
@@ -75,24 +75,13 @@ describe CommissioningService do
 
       it "notifies the action officers" do
         MailWorker.new.run!
-        ao1_mail, _,  ao2_mail, _ = ActionMailer::Base.deliveries
+        ao1_mail,  ao2_mail = ActionMailer::Base.deliveries
 
         expect(ao1_mail.to).to eq([ao1.email])
         expect(ao1_mail.subject).to match(/you have been allocated PQ #{pq.uin}/i)
 
         expect(ao2_mail.to).to eq([ao2.email])
         expect(ao2_mail.subject).to match(/you have been allocated PQ #{pq.uin}/i)
-      end
-
-      it "notifies the deputy director" do
-        MailWorker.new.run!
-        _, dd1_mail, _, dd2_mail = ActionMailer::Base.deliveries
-
-        expect(dd1_mail.to).to eq([ao1.deputy_director.email])
-        expect(dd1_mail.subject).to match(/#{ao1.name} has been allocated PQ #{pq.uin}/i)
-
-        expect(dd2_mail.to).to eq([ao2.deputy_director.email])
-        expect(dd2_mail.subject).to match(/#{ao2.name} has been allocated PQ #{pq.uin}/i)
       end
 
       it "sets the PQ state to 'no-response'" do


### PR DESCRIPTION
New business process, removes the need for emailing Deputy Directors.