### PR TITLE
96169910 - correctly check if deadline passed

### DIFF
--- a/app/views/shared/_deadline_time.html.slim
+++ b/app/views/shared/_deadline_time.html.slim
@@ -1,5 +1,4 @@
-- if internal_deadline && !is_closed
-  - from_time = DateTime.now.change ({:offset => 0})
-  - overdue = (from_time -  internal_deadline.to_datetime) > 0
-  - if overdue && draft_reply.blank?
+- if internal_deadline && !is_closed && draft_reply.blank?
+  - deadline_uk = Time.find_zone('London').parse(internal_deadline.to_s).to_datetime
+  - if deadline_uk < DateTime.now
     = render 'shared/warning_icon'


### PR DESCRIPTION
This fixes 2 errors when comparing times to check if a PQ is overdue:
1. the first time compared is the server time, stripped of its timezone offset. Eg, if it's 5am in the UK and the server is in Japan where it's 2pm, the server time will be returned as 2pm
2. the second time compared is the PQ's internal deadline. It is stored without time zone information and is converted as is to UK time (ie 2pm becomes 2pm GMT in the winter, and 2pm+1 in the summer)

The first error was probably introduced as a result of trying to fix the second one. Indeed, in winter and on a box that is set to UK timezone, both cancel each other out. But in the summer the result is one hour off, hence bug #96169910

This PR fixes both, although doesn't test for the 1st bug, as it doesn't seem to be possible to mock changing the system's timezone with rspec.