### PR TITLE
Dont ignore inactive aos

### DIFF
--- a/app/models/pq.rb
+++ b/app/models/pq.rb
@@ -99,11 +99,7 @@ class Pq < ActiveRecord::Base
       where(action_officers_pqs: {response: 'accepted'})
     end
 
-    def all_active_accepted
-      where(action_officers_pqs: {response: 'accepted'}, action_officers: { deleted: false} )
-    end
-
-    def accepted #TODO Need to change this to live or dead AOs - need data from PB to test.
+    def accepted
       where(action_officers_pqs: {response: 'accepted'}, action_officers: { deleted: false} ).first
     end
 

--- a/app/models/pq.rb
+++ b/app/models/pq.rb
@@ -100,7 +100,7 @@ class Pq < ActiveRecord::Base
     end
 
     def accepted
-      where(action_officers_pqs: {response: 'accepted'}, action_officers: { deleted: false} ).first
+      where(action_officers_pqs: {response: 'accepted'}).first
     end
 
     def rejected

--- a/app/models/pq.rb
+++ b/app/models/pq.rb
@@ -95,11 +95,15 @@ class Pq < ActiveRecord::Base
 
   has_many :action_officers, :through => :action_officers_pqs do
 
+    def all_accepted
+      where(action_officers_pqs: {response: 'accepted'})
+    end
+
     def all_active_accepted
       where(action_officers_pqs: {response: 'accepted'}, action_officers: { deleted: false} )
     end
 
-    def accepted
+    def accepted #TODO Need to change this to live or dead AOs - need data from PB to test.
       where(action_officers_pqs: {response: 'accepted'}, action_officers: { deleted: false} ).first
     end
 
@@ -231,8 +235,8 @@ class Pq < ActiveRecord::Base
   private
 
   def sole_accepted_action_officer
-    if action_officers.all_active_accepted.size > 1
-      errors[:base] << "Unable to have two active action officers accepted on the same question"
+    if action_officers.all_accepted.size > 1
+      errors[:base] << "Unable to have two action officers accepted on the same question"
     end
   end
 

--- a/spec/models/pq_spec.rb
+++ b/spec/models/pq_spec.rb
@@ -116,7 +116,7 @@ describe Pq do
       on_time_due_sooner_lower_weight   = pqs[1]
       on_time_due_later_higher_weight   = pqs[2]
       on_time_due_later_lower_weight    = pqs[3]
-      
+
       expect(Pq.sorted_for_dashboard.map(&:uin)).to eq([
         on_time_due_sooner_higher_weight,
         on_time_due_sooner_lower_weight,
@@ -506,7 +506,7 @@ describe Pq do
 
       let(:pq) do
         pq = FactoryGirl.create(:pq)
-        3.times do 
+        3.times do
           ao = FactoryGirl.create(:action_officer)
           pq.action_officers << ao
         end
@@ -528,7 +528,7 @@ describe Pq do
         expect(pq).to be_valid
       end
 
-      it 'should be valid if multiple accepted but only one of those is active' do
+      it 'should not be valid if multiple accepted but only one of those is active' do
         ao1 = pq.action_officers.order(:id).first
         ao1.deleted = true
         ao1.save!
@@ -541,9 +541,10 @@ describe Pq do
         end
         expect(pq.action_officers.order(:id).map(&:deleted)).to eq( [ true, true, false ] )
         expect(pq.action_officers_pqs.order(:id).map(&:response)).to eq([:accepted, :accepted, :accepted])
-        expect(pq).to be_valid
+        expect(pq).not_to be_valid
+        expect(pq.errors[:base]).to eq([ 'Unable to have two action officers accepted on the same question'])
       end
-      
+
 
       it 'should not be valid if multiple accepted active' do
         pq.action_officers_pqs.each do |aopq|
@@ -553,7 +554,7 @@ describe Pq do
         expect(pq.action_officers.order(:id).map(&:deleted)).to eq( [ false, false, false ] )
         expect(pq.action_officers_pqs.order(:id).map(&:response)).to eq([:accepted, :accepted, :accepted])
         expect(pq).not_to be_valid
-        expect(pq.errors[:base]).to eq([ 'Unable to have two active action officers accepted on the same question'])
+        expect(pq.errors[:base]).to eq([ 'Unable to have two action officers accepted on the same question'])
       end
   end
 


### PR DESCRIPTION
Fixes issue with Questions whose action officer has been inactivated - when the question was later saved, the progress flag inaccurately changed to 'Unallocated'
This was owing to a previous fix which did not take that scenario into account.