### PR TITLE
Update dockerfiles to use central registry base images

### DIFF
--- a/docker/assets/Dockerfile
+++ b/docker/assets/Dockerfile
@@ -2,7 +2,7 @@
 # sure you lock down to a specific version, not to `latest`!
 # See https://github.com/phusion/baseimage-docker/blob/master/Changelog.md for
 # a list of version numbers.
-FROM moj-nginx:latest
+FROM registry.service.dsd.io/moj-nginx:latest
 
 # Set correct environment variables.
 ENV HOME /root

--- a/docker/rails/Dockerfile
+++ b/docker/rails/Dockerfile
@@ -1,4 +1,4 @@
-FROM moj-ruby:latest
+FROM registry.service.dsd.io/moj-ruby:latest
 
 # Set correct environment variables.
 ENV HOME /root


### PR DESCRIPTION
These builds currently rely on a local version of moj-ruby and
moj-nginx being available. This change will properly direct them
to the versions on the central docker registry.