### PR TITLE
CC list error

### DIFF
--- a/app/models/press_desk.rb
+++ b/app/models/press_desk.rb
@@ -20,6 +20,7 @@ class PressDesk < ActiveRecord::Base
 
   def press_officer_emails
     press_officers
+      .reject(&:deleted?)
       .map(&:email)
       .reject(&:blank?)
   end

--- a/spec/models/press_desk_spec.rb
+++ b/spec/models/press_desk_spec.rb
@@ -29,11 +29,19 @@ describe PressDesk do
     expect(duplicate).to be_invalid
   end
 
-  it 'exploses a press_officer_emails method' do
+  it 'exposes a press_officer_emails method' do
     pdesk.press_officers << build(:press_officer, name: 'PO one', email: 'po.one@po.com')
     pdesk.press_officers << build(:press_officer, name: 'PO two', email: 'po.two@po.com')
 
     expect(pdesk.press_officer_emails).to eql(['po.one@po.com', 'po.two@po.com'])
+  end
+
+
+  it 'exposes a press_officer_emails method to not include deleted ones' do
+    pdesk.press_officers << build(:press_officer, name: 'PO one', email: 'po.one@po.com', deleted: true)
+    pdesk.press_officers << build(:press_officer, name: 'PO two', email: 'po.two@po.com', deleted: false)
+
+    expect(pdesk.press_officer_emails).to eql(['po.two@po.com'])
   end
 
   describe "associations" do


### PR DESCRIPTION
Press officers that are inactive won’t be added to the CC list anymore.