### PR TITLE
Adds explicit logging and removes warning

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,6 +29,8 @@ ParliamentaryQuestions::Application.configure do
   # number of complex assets.
   config.assets.debug = true
 
+  config.log_level = :debug
+
   # Custom Logging - unocmment this block if you want to see logstash-style logs written
   # to log/logstash_development.json.
   # A side effect of this is that the normal log/development.log will just contain SQL actions and

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,6 +82,8 @@ ParliamentaryQuestions::Application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
+  config.log_level = :info
+
   # Custom Logging
   config.logstasher.enabled = true
   config.logstasher.suppress_app_log = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -26,6 +26,9 @@ ParliamentaryQuestions::Application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
+  # log level
+  config.log_level = :debug
+
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.


### PR DESCRIPTION
Sometimes we get this warning:

```
. (called from block in tsort_each at /usr/local/lib/ruby/2.3.0/tsort.rb:228)
DEPRECATION WARNING: You did not specify a `log_level` in `production.rb`. Currently, the default value for `log_level` is `:info` for the production environment and `:debug` in all other environments. In Rails 5 the default value will be unified to `:debug` across all environments. To preserve the current setting, add the following line to your `production.rb`:

   config.log_level = :info
```
so now we specify an explicit log level for each environment.