### PR TITLE
Tweak environment detection in user creation task

### DIFF
--- a/docker-ng/rails/run-pq.sh
+++ b/docker-ng/rails/run-pq.sh
@@ -6,6 +6,12 @@ echo "rails startup"              | tee -a /usr/src/app/log/unicorn.log
 
 export PATH=/usr/src/app/bin:$PATH
 
+
+if [ -n "$CREATE_USER_FROM_TEST" ]; then
+    echo rails user changed to: ${TEST_USER%@*}
+    RAILS_USER="${TEST_USER}, ${TEST_USER_PASS}, ${TEST_USER%@*}"
+fi
+
 # We want to run scheduling and db tasks only on the master. For single box environments
 # APP_MASTER_SERVER will not be set so run all the time
 if [ -z "$APP_MASTER_SERVER" -o "$APPHOST" == "$APP_MASTER_SERVER" ]; then

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -2,8 +2,8 @@ namespace :user do
 
   desc 'Creates an user with given name, email and password.'
   task :create, [:email, :password, :name] => :environment do |t, args|
-    raise 'This task should NOT be run in a production environment' if Rails.env.production?
-    
+    raise 'This task should NOT be run in a production environment' if HostEnv.is_live?
+
     args.with_defaults(email: 'admin@admin.com', password: '123456789', name: 'User name')
     email, password, name = args[:email], args[:password],  args[:name]
 


### PR DESCRIPTION
    This change will detect the environment using HostEnv for the user creation 
    rake task. The Dev env in AWS is running with RAILS_ENV=production so when  
    seed/migration tasks are running currently no users are being created.

After merging this a user will be created during the "seed" rake task, in all envs except the real production. This means in "dev" an admin user will get created unless overridden by RAILS_USER. 