### PR TITLE
Amend rake task for prefixing old questions

### DIFF
--- a/lib/tasks/bugfix.rake
+++ b/lib/tasks/bugfix.rake
@@ -50,9 +50,10 @@ namespace :bugfix do
 
   desc 'Prefix uins for previous session'
   task :prefix_uins => :environment do
-    puts "Number of non-prefixed uins #{(Pq.where.not("uin like ?","#%").count)} "
-      Pq.where.not("uin like ?","#%").update_all("uin='*'||uin")
-    puts "Number of uins with * prefix #{(Pq.where("uin like ?","*%").count)} "
+    puts "Number of non-prefixed uins #{(Pq.where.not(("uin SIMILAR TO '(#|[ESCAPE *])%'")).count)} "
+    Pq.where.not(("uin SIMILAR TO '(#|[ESCAPE *])%'")).update_all("uin='$'||uin")
+    puts "Number of uins with $ prefix #{(Pq.where("uin like ?","$%").count)} "
+    puts "Post-update: Number of non-prefixed uins #{(Pq.where.not(("uin SIMILAR TO '(#|[ESCAPE *]|$)%'")).count)} "
   end
 
 


### PR DESCRIPTION
The API from Parliament does not treat each question's UIN as unique over time, instead the numbers reset at the beginning of a new Parliament. To avoid clash, though not elegantly, we prefix with a different character for each new Parliament. The application is due to be superceeded so this approach is effective in the short term.