### PR TITLE
Add missing env variable to setup instructions

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,8 +1,9 @@
 ###
-### These environment variables are defined as dummy variables to ensure the build packages correctly. 
+### These environment variables are defined as dummy variables to ensure the build packages correctly.
 ### They will never get used in production environments
-### 
+###
 DEVISE_SECRET=eed7c257fbffd3229ab2e32069c364084ddcfef3db7f902b43012a5bf03c8713be0cb3b484c48f658ddcad37393777fa4ba3dcc68fde32f684c0d4ebd03832d2
+DEVISE_SENDER=no-reply@digital.justice.gov.uk
 PQ_REST_API_HOST=http://localhost/i/am/never/used
 # Because we need to set env to "produciton" to generate assets, we need to set these two as wel
 PQ_REST_API_USERNAME=dummy

--- a/config/README.md
+++ b/config/README.md
@@ -4,10 +4,10 @@ This is an up to date list of the environment variables used by the app.
 Refer to the provisioning code for the actual values expected to be set on each
 specific environment.
 
-For local development, the only mandatory variables are `PQ_REST_API_HOST` and `TEST_USER_PASS`. `PQ_REST_API_HOST` should
+For local development, the only mandatory variables are `PQ_REST_API_HOST`, `DEVISE_SENDER` and `TEST_USER_PASS`. `PQ_REST_API_HOST` should
 be set to `http://localhost:8888`, as it is the default hostname/port used
 by the [mock implementation](https://github.com/ministryofjustice/parliamentary-questions/blob/dev/lib/pqa/mock_api_server_runner.rb)
-of Parliament's Question and Answer API. `TEST_USER_PASS` can be set to any value.
+of Parliament's Question and Answer API. `TEST_USER_PASS` can be set to any value. `DEVISE_SENDER` can be set to `no-reply@digital.justice.gov.uk`.
 
 Variable Name          |Required for local development  | Description
 -----------------------| ------------------------------ | -----------------------------
@@ -15,12 +15,12 @@ Variable Name          |Required for local development  | Description
 `PQ_REST_API_USERNAME` | n                              | Username
 `PQ_REST_API_PASSWORD` | n                              | Password
 `DEVISE_SECRET`        | n                              | Secret Devise Token
-`DEVISE_SENDER`        | n                              | Email address used for signup/signin/password related notifications
+`DEVISE_SENDER`        | y                              | Email address used for signup/signin/password related notifications
 `SENDING_HOST`         | n                              | Host for URLs in emails
 `SMTP_HOSTNAME`        | n                              | SMTP server host
 `SMTP_PORT`            | n                              | SMTP server port
 `SMTP_USERNAME`        | n                              | SMTP user name
-`SMTP_PASSWORD`        | n                              | SMPT password
+`SMTP_PASSWORD`        | n                              | SMTP password
 `CA_CERT`              | n                              | Absolute Path of the system's SSL certificates dir (e.g. `/etc/ssl/certs`)
 `WEB_CONCURRENCY`      | n                              | Number of unicorn workers to be spawned at startup time
 `ASSET_HOST`           | n                              | Host where Rails' assets pipeline will deploy the assets


### PR DESCRIPTION
After installing on a new machine we discovered an env variable that was needed to run the application locally was not specified in the README. This adds that it is needed to local development