### PR TITLE
Remove pagination and inactive accounts from admin pages.

### DIFF
--- a/app/controllers/action_officers_controller.rb
+++ b/app/controllers/action_officers_controller.rb
@@ -7,8 +7,6 @@ class ActionOfficersController < ApplicationController
                                     .order(deleted: :asc)
                                     .order(Arel.sql('lower(divisions.name)'))
                                     .order(Arel.sql('lower(action_officers.name)'))
-                                    .page(params[:page])
-                                    .per_page(15)
     update_page_title 'Action officers'
   end
 

--- a/app/controllers/actionlist_members_controller.rb
+++ b/app/controllers/actionlist_members_controller.rb
@@ -3,7 +3,9 @@ class ActionlistMembersController < ApplicationController
   before_action :set_actionlist_member, only: [:show, :edit, :update, :destroy]
 
   def index
-    @actionlist_members = ActionlistMember.all.order(:name.downcase)
+    @actionlist_members = ActionlistMember.active_list
+                                          .all
+                                          .order(:name.downcase)
     update_page_title('Actionlist members')
   end
 

--- a/app/controllers/deputy_directors_controller.rb
+++ b/app/controllers/deputy_directors_controller.rb
@@ -9,8 +9,6 @@ class DeputyDirectorsController < ApplicationController
                                       .order(deleted: :asc)
                                       .order(Arel.sql('lower(divisions.name)'))
                                       .order(Arel.sql('lower(deputy_directors.name)'))
-                                      .page(params[:page])
-                                      .per_page(15)
     update_page_title 'Deputy directors'
   end
 

--- a/app/controllers/directorates_controller.rb
+++ b/app/controllers/directorates_controller.rb
@@ -6,8 +6,6 @@ class DirectoratesController < ApplicationController
     @directorates = Directorate.active_list
                                .order(deleted: :asc)
                                .order(Arel.sql('lower(name)'))
-                               .page(params[:page])
-                               .per_page(15)
     update_page_title('Directorates')
   end
 

--- a/app/controllers/divisions_controller.rb
+++ b/app/controllers/divisions_controller.rb
@@ -9,8 +9,6 @@ class DivisionsController < ApplicationController
                          .order(deleted: :asc)
                          .order(Arel.sql('lower(directorates.name)'))
                          .order(Arel.sql('lower(divisions.name)'))
-                         .page(params[:page])
-                         .per_page(15)
     update_page_title('Divisions')
   end
 

--- a/app/controllers/early_bird_members_controller.rb
+++ b/app/controllers/early_bird_members_controller.rb
@@ -2,7 +2,9 @@ class EarlyBirdMembersController < ApplicationController
   before_action :authenticate_user!, PQUserFilter
 
   def index
-    @early_bird_members = EarlyBirdMember.all.order(Arel.sql('lower(name)'))
+    @early_bird_members = EarlyBirdMember.active_list
+                                         .all
+                                         .order(Arel.sql('lower(name)'))
     update_page_title('Early bird members')
   end
 

--- a/app/controllers/ogds_controller.rb
+++ b/app/controllers/ogds_controller.rb
@@ -3,7 +3,8 @@ class OgdsController < ApplicationController
   before_action :set_ogd, only: [:show, :edit, :update, :destroy]
 
   def index
-    @ogds = Ogd.order('lower(name)')
+    @ogds = Ogd.active_list
+               .order('lower(name)')
     update_page_title('Other Government Departments')
   end
 

--- a/app/controllers/press_desks_controller.rb
+++ b/app/controllers/press_desks_controller.rb
@@ -3,7 +3,9 @@ class PressDesksController < ApplicationController
   before_action :set_press_desk, only: [:show, :edit, :update, :destroy]
 
   def index
-    @press_desks = PressDesk.all.order('lower(name)')
+    @press_desks = PressDesk.active_list
+                            .all
+                            .order('lower(name)')
     update_page_title('Press Desks')
   end
 

--- a/app/controllers/watchlist_members_controller.rb
+++ b/app/controllers/watchlist_members_controller.rb
@@ -2,7 +2,9 @@ class WatchlistMembersController < ApplicationController
   before_action :authenticate_user!, PQUserFilter
 
   def index
-    @watchlist_members = WatchlistMember.all.order(Arel.sql('lower(name)'))
+    @watchlist_members = WatchlistMember.active_list
+                                        .all
+                                        .order(Arel.sql('lower(name)'))
     update_page_title('Watchlist members')
   end
 

--- a/app/models/actionlist_member.rb
+++ b/app/models/actionlist_member.rb
@@ -19,6 +19,6 @@ class ActionlistMember < ActiveRecord::Base
   validates :email, presence: true, uniqueness: true, on: :create
   # validates_format_of :email, with: Devise.email_regexp
   validates :email, format: { with: Devise.email_regexp }
-
+  scope :active_list, -> { where('actionlist_members.deleted = ? OR actionlist_members.deleted = ? AND actionlist_members.updated_at > ?', false, true, 2.days.ago.to_datetime) }
   before_validation Validators::Whitespace.new
 end

--- a/app/models/early_bird_member.rb
+++ b/app/models/early_bird_member.rb
@@ -5,8 +5,7 @@ class EarlyBirdMember < ActiveRecord::Base
   has_paper_trail
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true, on: :create
-  # validates_format_of :email, with: Devise.email_regexp
   validates :email, format: { with: Devise.email_regexp }
-
+  scope :active_list, -> { where('early_bird_members.deleted = ? OR early_bird_members.deleted = ? AND early_bird_members.updated_at > ?', false, true, 2.days.ago.to_datetime) }
   before_validation Validators::Whitespace.new
 end

--- a/app/models/ogd.rb
+++ b/app/models/ogd.rb
@@ -18,6 +18,7 @@ class Ogd < ActiveRecord::Base
   validates :name, presence: true
   validates :acronym, presence: true
   has_many :pqs
+  scope :active_list, -> { where('ogds.deleted = ? OR ogds.deleted = ? AND ogds.updated_at > ?', false, true, 2.days.ago.to_datetime) }
 
   def self.by_name(name)
     where('name ILIKE :search OR acronym ILIKE :search', search: "%#{name.strip}%")

--- a/app/models/press_desk.rb
+++ b/app/models/press_desk.rb
@@ -17,6 +17,7 @@ class PressDesk < ActiveRecord::Base
   validates :name, uniqueness: true, presence: true
   has_many :action_officers
   has_many :press_officers
+  scope :active_list, -> { where('press_desks.deleted = ? OR press_desks.deleted = ? AND press_desks.updated_at > ?', false, true, 2.days.ago.to_datetime) }
 
   def press_officer_emails
     press_officers

--- a/app/models/watchlist_member.rb
+++ b/app/models/watchlist_member.rb
@@ -19,6 +19,7 @@ class WatchlistMember < ActiveRecord::Base
   validates :email, presence: true, uniqueness: true, on: :create
   # validates_format_of :email, with: Devise.email_regexp
   validates :email, format: { with: Devise.email_regexp }
+  scope :active_list, -> { where('watchlist_members.deleted = ? OR watchlist_members.deleted = ? AND watchlist_members.updated_at > ?', false, true, 2.days.ago.to_datetime) }
 
   before_validation Validators::Whitespace.new
 end

--- a/app/views/action_officers/index.html.slim
+++ b/app/views/action_officers/index.html.slim
@@ -20,5 +20,3 @@ h1 Action officers
           td= action_officer.press_desk.name unless action_officer.press_desk.nil?
           td= render partial: 'shared/status', object: action_officer
           td.edit= link_to 'Edit', edit_action_officer_path(action_officer)
-  .pagination-row.bottom
-    .page-entries= will_paginate @action_officers

--- a/app/views/actionlist_members/index.html.slim
+++ b/app/views/actionlist_members/index.html.slim
@@ -1,7 +1,7 @@
 = render partial: "shared/flash_messages", flash: flash
 h1 Actionlist members
 #admin-al-list
-  div class="row"
+  .row
     ul#admin-button-bar
       li= link_to ('Add actionlist member'), new_actionlist_member_path, {class: 'button-secondary'}
   table.table

--- a/app/views/deputy_directors/index.html.slim
+++ b/app/views/deputy_directors/index.html.slim
@@ -17,5 +17,3 @@ h1 Deputy directors
           td= deputy_director.division.name
           td= render partial: 'shared/status', object: deputy_director
           td.edit= link_to 'Edit', edit_deputy_director_path(deputy_director)
-  .pagination-row.bottom
-    .page-entries= will_paginate @deputy_directors

--- a/app/views/directorates/index.html.slim
+++ b/app/views/directorates/index.html.slim
@@ -15,5 +15,3 @@ h1 Directorates
           td= link_to directorate.name, directorate_path(directorate)
           td= render partial: 'shared/status', object: directorate
           td.edit= link_to 'Edit', edit_directorate_path(directorate)
-  .pagination-row.bottom
-    .page-entries= will_paginate @directorates

--- a/app/views/divisions/index.html.slim
+++ b/app/views/divisions/index.html.slim
@@ -17,5 +17,3 @@ h1 Divisions
           td= division.directorate.name
           td= render partial: 'shared/status', object: division
           td.edit= link_to 'Edit', edit_division_path(division)
-  .pagination-row.bottom
-    .page-entries= will_paginate @divisions

--- a/app/views/early_bird_members/index.html.slim
+++ b/app/views/early_bird_members/index.html.slim
@@ -1,7 +1,7 @@
 = render partial: "shared/flash_messages", flash: flash
 h1 Early bird members
 #admin-wm-list
-  div class="row"
+  .row
     ul#admin-button-bar
       li= link_to ('Send early bird info'), {controller: 'early_bird_send_emails', action: 'send_emails'}, {class: 'button', :onclick=> "ga('send', 'event', 'settings', 'earlybird', 'send early bird info');" }
       li= link_to ('Add early bird member'), new_early_bird_member_path, {class: 'button-secondary'}


### PR DESCRIPTION
Removed pagination from:
- Action Officers
- Deputy Directors
- Directorates
- Divisions

Removed inactive entries 48 hours after deactivation from: 
- Action list
- Early bird list
- Other Government Departments
- Press desks
- Watch list