### PR TITLE
Suppress the sending of early bird emails until Parliament restarts.

### DIFF
--- a/lib/tasks/early_bird.rake
+++ b/lib/tasks/early_bird.rake
@@ -3,7 +3,7 @@ namespace :pqa do
   task :early_bird, [] => :environment do
     begin
       if PqaImportRun.ready_for_early_bird
-        if (Time.zone.today < Date.new(2019, 11, 6)) || (Time.zone.today > Date.new(2019, 12, 19))
+        if (Time.zone.today < Date.new(2019, 12, 23)) || (Time.zone.today > Date.new(2020, 1, 6))
           LogStuff.info { 'Early Bird: Preparing to queue early bird mails' }
           service = EarlyBirdReportService.new
           service.notify_early_bird


### PR DESCRIPTION
Sending blocked between 23/12/2019 and 06/01/2020.