### PR TITLE
Rename references to Dev environment DB

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,13 +19,13 @@ references:
           PG_USER: postgres
           PGUSER: postgres
           PGHOST: 127.0.0.1
-          POSTGRES_DB: parliamentary-questions_test
+          POSTGRES_DB: parliamentary_questions_test
 
       - image: postgres:10
         environment:
           PG_PASSWORD: ""
           PG_USER: postgres
-          POSTGRES_DB: parliamentary-questions_test
+          POSTGRES_DB: parliamentary_questions_test
           POSTGRES_USER: postgres
           PGUSER: postgres
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,7 @@
 development:
   adapter: postgresql
   encoding: unicode
-  database: parliamentary-questions_dev
+  database: parliamentary_questions_dev
   username: <%= ENV['DB_USERNAME'] || ENV['PGUSER'] || 'postgres' %>
   password: <%= ENV['DB_PASSWORD'] || ENV['PGPASSWORD'] || 'postgres' %>
   host: <%= ENV['DB_HOST'] || 'localhost' %>
@@ -10,7 +10,7 @@ development:
 test: &test
   adapter: postgresql
   encoding: unicode
-  database: parliamentary-questions_test
+  database: parliamentary_questions_test
   host: <%= ENV['DB_HOST'] || 'localhost' %>
   pool: 10
 

--- a/spec/health_check/database_spec.rb
+++ b/spec/health_check/database_spec.rb
@@ -32,7 +32,7 @@ describe HealthCheck::Database do
       db.available?
 
       expect(db.error_messages).to eq([
-                                        'Database Error: could not connect to parliamentary-questions_test ' \
+                                        'Database Error: could not connect to parliamentary_questions_test ' \
                                         'on localhost using postgresql'
                                       ])
     end


### PR DESCRIPTION
From parliamentary-questions_test to parliamentary_questions_test as hyphens in the DB name break the our build pipeline.