### PR TITLE
Fix url in email and sending host regex

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,7 +57,7 @@ ParliamentaryQuestions::Application.configure do
     ActionMailer::Base.delivery_method = :sendmail
     ActionMailer::Base.default from: Settings.mail_from
     ActionMailer::Base.default reply_to: Settings.mail_reply_to
-    ActionMailer::Base.default_url_options = { host: sending_host, protocol: 'http', port: '3000' }
+    ActionMailer::Base.default_url_options = { host: sending_host, protocol: 'http' }
     ActionMailer::Base.smtp_settings = {
       address: ENV['SMTP_HOSTNAME'] || 'localhost',
       authentication: :login,

--- a/config/initializers/host_env.rb
+++ b/config/initializers/host_env.rb
@@ -2,14 +2,14 @@ module HostEnv
   extend self
 
   def is_live?
-    ENV['SENDING_HOST'] =~ /trackparliamentaryquestions.service.gov.uk/
+    ENV['SENDING_HOST'] =~ /^trackparliamentaryquestions.service.gov.uk/
   end
 
   def is_staging?
-    ENV['SENDING_HOST'] =~ /parliamentary-questions-staging.apps.live-1.cloud-platform.service.justice.gov.uk/
+    ENV['SENDING_HOST'] =~ /^parliamentary-questions-staging.apps.live-1.cloud-platform.service.justice.gov.uk/
   end
 
   def is_dev?
-    ENV['SENDING_HOST'] =~ /development.trackparliamentaryquestions.service.gov.uk/
+    ENV['SENDING_HOST'] =~ /^development.trackparliamentaryquestions.service.gov.uk/
   end
 end

--- a/k8s-deploy/development/deployment.yaml
+++ b/k8s-deploy/development/deployment.yaml
@@ -43,7 +43,7 @@ spec:
               name: GOVUK_NOTIFY_API_KEY
               valueFrom: 
                 secretKeyRef:
-                  key: govuk_notify_api_key
+                  key: GOVUK_NOTIFY_API_KEY
                   name: pq-secrets
           envFrom:
             -

--- a/k8s-deploy/development/migration_job.yaml
+++ b/k8s-deploy/development/migration_job.yaml
@@ -35,7 +35,7 @@ spec:
               name: GOVUK_NOTIFY_API_KEY
               valueFrom:
                 secretKeyRef:
-                  key: govuk_notify_api_key
+                  key: GOVUK_NOTIFY_API_KEY
                   name: pq-secrets
           envFrom:
             -

--- a/k8s-deploy/staging/trim_and_anonymise_database_cronjob.yaml
+++ b/k8s-deploy/staging/trim_and_anonymise_database_cronjob.yaml
@@ -43,7 +43,7 @@ spec:
                   name: GOVUK_NOTIFY_API_KEY
                   valueFrom: 
                     secretKeyRef:
-                      key: GOVUK_NOTIFY_API_KEY  
+                      key: GOVUK_NOTIFY_API_KEY
                       name: pq-secrets
               envFrom:
                 -


### PR DESCRIPTION
The URL generated for the emails included a port number from the
ActionBaseMailer settings in the config environments, this removes
where it is set.

Also fixes an issue where HostEnv.is_live? returns true for development
due to the regex ignoring the development prefix in the url. This caused
the migrations to error when deploying to development.