### PR TITLE
Fix Rubocop errors

### DIFF
--- a/app/mailers/notify_pq_mailer.rb
+++ b/app/mailers/notify_pq_mailer.rb
@@ -93,7 +93,7 @@ class NotifyPqMailer < GovukNotifyRails::Mailer
     mail(to: email)
   end
 
-  # empty comment
+  # empty comment 2
 
   def watchlist_email(email:, token:, entity:)
     set_template('b452ebb8-c49e-46f6-9da5-3ba28b494ed6')

--- a/app/mailers/notify_pq_mailer.rb
+++ b/app/mailers/notify_pq_mailer.rb
@@ -86,7 +86,9 @@ class NotifyPqMailer < GovukNotifyRails::Mailer
     set_template('e0700ef3-8a63-4041-ae97-323a1e62272f')
     set_personalisation(
       formatted_date: (Time.zone.today.strftime '%d/%m/%Y'),
-      early_bird_link: URI::escape(early_bird_dashboard_url(token: token, entity: entity)),
+      # early_bird_link: URI::escape(early_bird_dashboard_url(token: token, entity: entity)),
+      # early_bird_link: URI.encode_www_form_component(early_bird_dashboard_url(token: token, entity: entity)),
+      early_bird_link: CGI.escape(early_bird_dashboard_url(token: token, entity: entity)),
       reply_to_email: Settings.mail_reply_to
     )
     set_email_reply_to(Settings.parliamentary_team_email)

--- a/app/mailers/notify_pq_mailer.rb
+++ b/app/mailers/notify_pq_mailer.rb
@@ -86,8 +86,6 @@ class NotifyPqMailer < GovukNotifyRails::Mailer
     set_template('e0700ef3-8a63-4041-ae97-323a1e62272f')
     set_personalisation(
       formatted_date: (Time.zone.today.strftime '%d/%m/%Y'),
-      # early_bird_link: URI::escape(early_bird_dashboard_url(token: token, entity: entity)),
-      # early_bird_link: URI.encode_www_form_component(early_bird_dashboard_url(token: token, entity: entity)),
       early_bird_link: CGI.escape(early_bird_dashboard_url(token: token, entity: entity)),
       reply_to_email: Settings.mail_reply_to
     )

--- a/app/mailers/notify_pq_mailer.rb
+++ b/app/mailers/notify_pq_mailer.rb
@@ -93,8 +93,6 @@ class NotifyPqMailer < GovukNotifyRails::Mailer
     mail(to: email)
   end
 
-  # empty comment 2
-
   def watchlist_email(email:, token:, entity:)
     set_template('b452ebb8-c49e-46f6-9da5-3ba28b494ed6')
     set_personalisation(

--- a/app/mailers/notify_pq_mailer.rb
+++ b/app/mailers/notify_pq_mailer.rb
@@ -93,6 +93,8 @@ class NotifyPqMailer < GovukNotifyRails::Mailer
     mail(to: email)
   end
 
+  # empty comment
+
   def watchlist_email(email:, token:, entity:)
     set_template('b452ebb8-c49e-46f6-9da5-3ba28b494ed6')
     set_personalisation(

--- a/lib/presenters/email.rb
+++ b/lib/presenters/email.rb
@@ -65,7 +65,7 @@ module Presenters
     def finance_users_emails(pq)
       if pq.finance_interest
         emails = User.finance.where('email IS NOT NULL').map(&:email)
-        "finance #{emails} and " 
+        "finance #{emails} and "
       else
         []
       end


### PR DESCRIPTION
Replace depricated URI.escape method call with CGI.escape.
Remove trailing white space.