### PR TITLE
Output correct environment name in import email.

### DIFF
--- a/app/mailers/notify_import_mailer.rb
+++ b/app/mailers/notify_import_mailer.rb
@@ -2,7 +2,7 @@ class NotifyImportMailer < GovukNotifyRails::Mailer
   def notify_fail(error_message)
     set_template('586dd10e-8987-4754-b653-9cacd3763d19')
     set_personalisation(
-      environment: app_env,
+      environment: ENV['RAILS_ENV'],
       error_message: error_message
     )
     set_email_reply_to(Settings.tech_support_email)
@@ -12,27 +12,12 @@ class NotifyImportMailer < GovukNotifyRails::Mailer
   def notify_success(report)
     set_template('7858c6b6-774e-47f5-80c2-bea221805bb7')
     set_personalisation(
-      environment: app_env,
+      environment: ENV['RAILS_ENV'],
       total_questions: report[:total],
       questions_created: report[:created],
       questions_updated: report[:updated]
     )
     set_email_reply_to(Settings.tech_support_email)
     mail(to: Settings.mail_tech_support)
-  end
-
-  private
-
-  def app_env
-    case ENV['SENDING_HOST']
-    when 'trackparliamentaryquestions.service.gov.uk'
-      'production'
-    when 'parliamentary-questions-staging.apps.live-1.cloud-platform.service.justice.gov.uk'
-      'staging'
-    when 'development.trackparliamentaryquestions.service.gov.uk'
-      'dev'
-    else
-      'env-unknown'
-    end
   end
 end

--- a/app/mailers/notify_import_mailer.rb
+++ b/app/mailers/notify_import_mailer.rb
@@ -2,7 +2,7 @@ class NotifyImportMailer < GovukNotifyRails::Mailer
   def notify_fail(error_message)
     set_template('586dd10e-8987-4754-b653-9cacd3763d19')
     set_personalisation(
-      environment: ENV['RAILS_ENV'],
+      environment: app_env,
       error_message: error_message
     )
     set_email_reply_to(Settings.tech_support_email)
@@ -12,12 +12,22 @@ class NotifyImportMailer < GovukNotifyRails::Mailer
   def notify_success(report)
     set_template('7858c6b6-774e-47f5-80c2-bea221805bb7')
     set_personalisation(
-      environment: ENV['RAILS_ENV'],
+      environment: app_env,
       total_questions: report[:total],
       questions_created: report[:created],
       questions_updated: report[:updated]
     )
     set_email_reply_to(Settings.tech_support_email)
     mail(to: Settings.mail_tech_support)
+  end
+
+  private
+
+  def app_env
+    if ENV['RAILS_ENV'] != 'development' && ENV['RAILS_ENV'] != 'staging' && ENV['RAILS_ENV'] != 'production'
+      'env-unknown'
+    else
+      ENV['RAILS_ENV']
+    end
   end
 end

--- a/app/mailers/notify_import_mailer.rb
+++ b/app/mailers/notify_import_mailer.rb
@@ -1,8 +1,9 @@
 class NotifyImportMailer < GovukNotifyRails::Mailer
   def notify_fail(error_message)
+    # Setup GOV.UK Notify mailer variables
     set_template('586dd10e-8987-4754-b653-9cacd3763d19')
     set_personalisation(
-      environment: app_env,
+      environment: ENV['RAILS_ENV'],
       error_message: error_message
     )
     set_email_reply_to(Settings.tech_support_email)
@@ -10,24 +11,15 @@ class NotifyImportMailer < GovukNotifyRails::Mailer
   end
 
   def notify_success(report)
+    # Setup GOV.UK Notify mailer variables
     set_template('7858c6b6-774e-47f5-80c2-bea221805bb7')
     set_personalisation(
-      environment: app_env,
+      environment: ENV['RAILS_ENV'],
       total_questions: report[:total],
       questions_created: report[:created],
       questions_updated: report[:updated]
     )
     set_email_reply_to(Settings.tech_support_email)
     mail(to: Settings.mail_tech_support)
-  end
-
-  private
-
-  def app_env
-    if ENV['RAILS_ENV'] != 'development' && ENV['RAILS_ENV'] != 'staging' && ENV['RAILS_ENV'] != 'production'
-      'env-unknown'
-    else
-      ENV['RAILS_ENV']
-    end
   end
 end

--- a/spec/mailers/notify_import_mailer_spec.rb
+++ b/spec/mailers/notify_import_mailer_spec.rb
@@ -14,7 +14,7 @@ describe NotifyImportMailer, type: :mailer do
     it 'sets the personalisation in the email' do
       expect(mail.govuk_notify_personalisation)
         .to eq(
-          environment: 'env-unknown',
+          environment: 'test',
           error_message: StandardError
         )
     end
@@ -41,7 +41,7 @@ describe NotifyImportMailer, type: :mailer do
     it 'sets the personalisation in the email' do
       expect(mail.govuk_notify_personalisation)
         .to eq(
-          environment: 'env-unknown',
+          environment: 'test',
           total_questions: 4,
           questions_created: 3,
           questions_updated: 0

--- a/spec/mailers/notify_import_mailer_spec.rb
+++ b/spec/mailers/notify_import_mailer_spec.rb
@@ -14,7 +14,7 @@ describe NotifyImportMailer, type: :mailer do
     it 'sets the personalisation in the email' do
       expect(mail.govuk_notify_personalisation)
         .to eq(
-          environment: 'test',
+          environment: 'env-unknown',
           error_message: StandardError
         )
     end
@@ -41,7 +41,7 @@ describe NotifyImportMailer, type: :mailer do
     it 'sets the personalisation in the email' do
       expect(mail.govuk_notify_personalisation)
         .to eq(
-          environment: 'test',
+          environment: 'env-unknown',
           total_questions: 4,
           questions_created: 3,
           questions_updated: 0


### PR DESCRIPTION
- RAILS_ENV set correctly for each environment so SENDING_HOST comparision not needed
-  In local tests the RAILS_ENV set to 'test' therefore tests amended appropriately.