### PR TITLE
Added maintenance page and banner

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,23 +57,26 @@ class ApplicationController < ActionController::Base
     @page_title = "#{prefix} - #{suffix}"
   end
 
-  # rubocop:disable AndOr
+  # rubocop:disable Style/AndOr
   def maintenance_mode
-   redirect_to '/' and return unless maintenance_mode_on?
-   render layout: nil, file: 'layouts/maintenance'
+    redirect_to '/' and return unless maintenance_mode_on?
+    render layout: nil, file: 'layouts/maintenance'
   end
+  # rubocop:enable Style/AndOr
 
   protected
 
   def maintenance_mode_on?
-   File.exist? Rails.root.join('maintenance.txt')
+    File.exist? Rails.root.join('maintenance.txt')
   end
 
+  # rubocop:disable Style/AndOr
   def check_maintenance_mode
-   if maintenance_mode_on? && request.fullpath != '/maintenance'
-     redirect_to '/maintenance' and return
-   end
+    if maintenance_mode_on? && request.fullpath != '/maintenance'
+      redirect_to('/maintenance') and (return)
+    end
   end
+  # rubocop:enable Style/AndOr
 
   def ssl_excepted?
     Settings.excepted_from_ssl.any? do |excepted_path|

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   before_action :set_am_host
   before_action :set_page_title
   before_action :set_paper_trail_whodunnit
+  before_action :check_maintenance_mode
 
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
@@ -56,7 +57,23 @@ class ApplicationController < ActionController::Base
     @page_title = "#{prefix} - #{suffix}"
   end
 
+  # rubocop:disable AndOr
+  def maintenance_mode
+   redirect_to '/' and return unless maintenance_mode_on?
+   render layout: nil, file: 'layouts/maintenance'
+  end
+
   protected
+
+  def maintenance_mode_on?
+   File.exist? Rails.root.join('maintenance.txt')
+  end
+
+  def check_maintenance_mode
+   if maintenance_mode_on? && request.fullpath != '/maintenance'
+     redirect_to '/maintenance' and return
+   end
+  end
 
   def ssl_excepted?
     Settings.excepted_from_ssl.any? do |excepted_path|

--- a/app/views/layouts/_banner.html.slim
+++ b/app/views/layouts/_banner.html.slim
@@ -1,0 +1,20 @@
+.grid-row
+  .column-full
+    .survey.moj-banner
+      .message
+        <svg class="moj-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="40" width="40">
+        <path d="M13.7,18.5h-2.4v-2.4h2.4V18.5z M12.5,13.7c-0.7,0-1.2-0.5-1.2-1.2V7.7c0-0.7,0.5-1.2,1.2-1.2s1.2,0.5,1.2,1.2v4.8
+        C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S19.1,0.5,12.5,0.5z" /></svg>
+
+        .message_text This service will be down for essential maintenance for two hours from 13.00 on Wednesday 18 March. The site should resume service after this time.
+
+          Please contact us on <a href="mailto:pqsupport@digital.justice.gov.uk">pqsupport@digital.justice.gov.uk</a> if you continue to experience issues after this time. Apologies for the inconvenience.
+
+
+
+css:
+  .message { position: relative; }
+  svg { position: absolute; top: 0; left: 0; }
+  .moj-banner { border: 4px solid #1d70b8; padding: 2rem; margin-top: 2rem; margin-bottom: 2rem }
+  .moj-banner__icon { color: #1d70b8; vertical-align: middle; padding-right: 8px }
+  .message_text {  margin-left: 52px; padding-top: 9px; }

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -20,6 +20,7 @@
 
 - content_for :content do
   main#content(role="main")
+    = render partial: 'layouts/banner'
     .phase-banner
       / p.phase-tag = config_item(:phase).upcase )(this line is kept incase the moj elements change and this line needs to be reinstated!)
       <span>This is a new service - Your&nbsp;

--- a/app/views/layouts/maintenance.html.slim
+++ b/app/views/layouts/maintenance.html.slim
@@ -1,0 +1,57 @@
+- content_for :logo_link_title do
+  = "Return to home page"
+
+- content_for :homepage_url do
+  = root_path
+
+- content_for :header_class do
+ = "with-proposition"
+- content_for :global_header_text do
+  = t('common.service_name')
+
+- content_for :head do
+  meta name="format-detection" content="telephone=no" /
+
+  = stylesheet_link_tag "application", media: "all"
+  = stylesheet_link_tag "print", media: "print"
+
+  /[if lte IE 9]
+    = stylesheet_link_tag "ie_shame", media: "all"
+
+  - content_for :body_classes do
+    = "controller-" + controller.controller_name
+
+
+
+
+= content_for :content do
+  = csrf_meta_tags
+  = render partial: 'layouts/phase_banner'
+
+  .grid-row
+    .column-full
+      main#content
+        = render partial: 'layouts/flashes' unless flash.empty?
+        h1.page-heading style="border-bottom: 1px solid #000"
+          = "Service down for planned maintenance"
+        p.lede  This service will be down for essential maintenance during the afternoon of Wednesday 13 November. You will not have access after 13.00 on this day – the site will likely resume service after business hours. Apologies for the inconvenience.
+
+- content_for :body_end do
+  = javascript_include_tag "application"
+  - unless Rails.env.test?
+    javascript:
+      (function (i, s, o, g, r, a, m) {
+        i['GoogleAnalyticsObject'] = r;
+        i[r] = i[r] || function () {
+                  (i[r].q = i[r].q || []).push(arguments)
+                }, i[r].l = 1 * new Date();
+        a = s.createElement(o), m = s.getElementsByTagName(o)[0];
+        a.async = 1;
+        a.src = g;
+        m.parentNode.insertBefore(a, m)
+      })
+      (window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+      ga('create', '#{Rails.configuration.ga_tracking_id}', 'auto');
+      ga('send', 'pageview');
+
+= render template: 'layouts/govuk_template'

--- a/app/views/layouts/maintenance.html.slim
+++ b/app/views/layouts/maintenance.html.slim
@@ -33,7 +33,8 @@
         = render partial: 'layouts/flashes' unless flash.empty?
         h1.page-heading style="border-bottom: 1px solid #000"
           = "Service down for planned maintenance"
-        p.lede  This service will be down for essential maintenance during the afternoon of Wednesday 13 November. You will not have access after 13.00 on this day – the site will likely resume service after business hours. Apologies for the inconvenience.
+        p.lede  This service is down for essential maintenance. The service will likely resume by 15.00, but some users may still be unable to access it for up to 24 hours. Please contact us on <a href="mailto:pqsupport@digital.justice.gov.uk">pqsupport@digital.justice.gov.uk</a> if you continue to experience issues after this time.
+        p.lede Apologies for the inconvenience.
 
 - content_for :body_end do
   = javascript_include_tag "application"

--- a/app/views/layouts/maintenance.html.slim
+++ b/app/views/layouts/maintenance.html.slim
@@ -7,7 +7,7 @@
 - content_for :header_class do
  = "with-proposition"
 - content_for :global_header_text do
-  = t('common.service_name')
+  = "PQ Tracker"
 
 - content_for :head do
   meta name="format-detection" content="telephone=no" /
@@ -26,7 +26,6 @@
 
 = content_for :content do
   = csrf_meta_tags
-  = render partial: 'layouts/phase_banner'
 
   .grid-row
     .column-full
@@ -38,20 +37,5 @@
 
 - content_for :body_end do
   = javascript_include_tag "application"
-  - unless Rails.env.test?
-    javascript:
-      (function (i, s, o, g, r, a, m) {
-        i['GoogleAnalyticsObject'] = r;
-        i[r] = i[r] || function () {
-                  (i[r].q = i[r].q || []).push(arguments)
-                }, i[r].l = 1 * new Date();
-        a = s.createElement(o), m = s.getElementsByTagName(o)[0];
-        a.async = 1;
-        a.src = g;
-        m.parentNode.insertBefore(a, m)
-      })
-      (window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
-      ga('create', '#{Rails.configuration.ga_tracking_id}', 'auto');
-      ga('send', 'pageview');
 
 = render template: 'layouts/govuk_template'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,8 @@ ParliamentaryQuestions::Application.routes.draw do
   get 'reports/press_desk_by_progress' => 'reports#press_desk_by_progress'
   match 'reports/filter_all'           => 'reports#filter_all', via: [:get, :post], as: 'filter_all'
 
+  get '/maintenance', to: 'application#maintenance_mode'
+
   if Rails.env.development?
     mount_rails_db_info as: 'rails_db_info_engine'
     # mount_rails_db_info is enough for rails version < 4


### PR DESCRIPTION
In order to prevent users from editing the database or uploading files - or changing any sort of state, in fact - during our migration to Cloud Platform, this PR introduces "Maintenance mode"

When a file is present in the rails root directory named maintenance.txt then the app redirects all HTTP requests to maintenance page.

When the file is not present, the app functions as normal.

Can't do a feature spec for this because it will break parallel tests - as soon as we write the file for the test in one thread to check the app behaviour, any other tests will break.

But as long as the test suite passes otherwise, I think we should be good.

This PR adds the banner when site is on and maintenance page when site is off

![image](https://user-images.githubusercontent.com/1161161/76560120-65908c80-6498-11ea-8dd1-dbeb1628a1ef.png)

![image](https://user-images.githubusercontent.com/1161161/76560181-82c55b00-6498-11ea-929c-3763bfb055cc.png)

