### PR TITLE
Update trim_and_sanitize_db_cronjob.yaml

### DIFF
--- a/k8s-deploy/staging/trim_and_sanitize_db_cronjob.yaml
+++ b/k8s-deploy/staging/trim_and_sanitize_db_cronjob.yaml
@@ -11,8 +11,9 @@ spec:
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 1
   schedule: "0 6 * * *"
-  startingDeadlineSeconds: 10
+  startingDeadlineSeconds: 60
   successfulJobsHistoryLimit: 3
+  suspend: false
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
- Increased start deadline key to 60 seconds.
- Add false to suspend key.