### PR TITLE
Fix failing early bird and watchlist tests.

### DIFF
--- a/app/services/early_bird_report_service.rb
+++ b/app/services/early_bird_report_service.rb
@@ -18,7 +18,7 @@ class EarlyBirdReportService
     $statsd.increment "#{StatsHelper::TOKENS_GENERATE}.earlybird"
     recipients.each do |recipient|
       LogStuff.tag(:mailer_early_bird) do
-        LogStuff.info { "Early bird  email to pqtest@digital.justice.gov.uk} (name early_bird) [CCd to #{recipients.join(';')}]" }
+        LogStuff.info { "Early bird email to pqtest@digital.justice.gov.uk} (name early_bird) [CCd to #{recipients.join(';')}]" }
         NotifyPqMailer.early_bird_email(email: recipient, token: token, entity: entity).deliver_now
       end
     end

--- a/spec/services/early_bird_report_service_spec.rb
+++ b/spec/services/early_bird_report_service_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe 'EarlyBirdReportService' do
-  let!(:early_bird_one)     { create(:early_bird_member, name: 'member 1', email: 'm1@ao.gov', deleted: false) }
-  let!(:early_bird_two)     { create(:early_bird_member, name: 'member 2', email: 'm2@ao.gov', deleted: false) }
+  let!(:early_bird_one) { create(:early_bird_member, name: 'member 1', email: 'm1@ao.gov', deleted: false) }
+  let!(:early_bird_two) { create(:early_bird_member, name: 'member 2', email: 'm2@ao.gov', deleted: false) }
   let!(:early_bird_deleted) { create(:early_bird_member, name: 'member 3', email: 'm3@ao.gov', deleted: true) }
-  let(:testid)              { 'early_bird-' + DateTime.now.to_s.tr(' ', '-').tr('/', '-').tr(':', '-') }
+  let(:testid) { 'early_bird-' + DateTime.now.utc.to_s.tr(' ', '-').tr('/', '-').tr(':', '-') }
 
   before(:each) do
     @report_service = EarlyBirdReportService.new
@@ -31,7 +31,6 @@ describe 'EarlyBirdReportService' do
 
     expect(NotifyPqMailer).to have_received(:early_bird_email).with(email: 'm1@ao.gov', token: token, entity: testid)
     expect(NotifyPqMailer).to have_received(:early_bird_email).with(email: 'm2@ao.gov', token: token, entity: testid)
-
     expect(NotifyPqMailer).not_to have_received(:early_bird_email).with(email: 'm3@ao.gov')
   end
 end

--- a/spec/services/watchlist_report_service_spec.rb
+++ b/spec/services/watchlist_report_service_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe 'WatchlistReportService' do
-  let!(:watchlist_one)     { create(:watchlist_member, name: 'member 1', email: 'm1@ao.gov', deleted: false) }
-  let!(:watchlist_two)     { create(:watchlist_member, name: 'member 2', email: 'm2@ao.gov', deleted: false) }
+  let!(:watchlist_one) { create(:watchlist_member, name: 'member 1', email: 'm1@ao.gov', deleted: false) }
+  let!(:watchlist_two) { create(:watchlist_member, name: 'member 2', email: 'm2@ao.gov', deleted: false) }
   let!(:watchlist_deleted) { create(:watchlist_member, name: 'member 3', email: 'm3@ao.gov', deleted: true) }
-  let(:testid)             { 'watchlist-' + DateTime.now.to_s }
+  let(:testid) { 'watchlist-' + DateTime.now.utc.to_s }
 
   before(:each) do
     @report_service = WatchlistReportService.new
@@ -19,7 +19,6 @@ describe 'WatchlistReportService' do
     end_of_day = DateTime.current.end_of_day
 
     expect(token.expire.to_s).to eq(end_of_day.to_s)
-
     expect(
       Token.exists?(entity: "watchlist:#{watchlist_deleted.id}", path: '/watchlist/dashboard')
     ).to eq(false)
@@ -32,7 +31,6 @@ describe 'WatchlistReportService' do
 
     expect(NotifyPqMailer).to have_received(:watchlist_email).with(email: 'm1@ao.gov', token: token, entity: testid)
     expect(NotifyPqMailer).to have_received(:watchlist_email).with(email: 'm2@ao.gov', token: token, entity: testid)
-
     expect(NotifyPqMailer).not_to have_received(:watchlist_email).with(email: 'm3@ao.gov')
   end
 end

--- a/spec/support/features/pq_helpers.rb
+++ b/spec/support/features/pq_helpers.rb
@@ -72,7 +72,7 @@ module Features
       click_on 'Save'
     end
 
-    def visit_watchlist_url(expiry = DateTime.now)
+    def visit_watchlist_url(expiry = DateTime.now.utc)
       token_db = Token.find_by(path: watchlist_dashboard_path, expire: expiry.end_of_day)
       entity = token_db.entity
       token = TokenService.new.generate_token(token_db.path, token_db.entity, token_db.expire.end_of_day)
@@ -80,8 +80,8 @@ module Features
       visit watchlist_dashboard_url(token: token, entity: entity)
     end
 
-    def visit_earlybird_url(expiry = DateTime.now)
-      token_db = Token.find_by(path: early_bird_dashboard_path, expire: expiry.end_of_day.utc)
+    def visit_earlybird_url(expiry = DateTime.now.utc)
+      token_db = Token.find_by(path: early_bird_dashboard_path, expire: expiry.end_of_day)
       entity = token_db.entity
       token = TokenService.new.generate_token(token_db.path, token_db.entity, token_db.expire)
 


### PR DESCRIPTION
Use DateTime.now.utc to standardise test time as daylight saving transition causing tests to fail.