### PR TITLE
Bump rubocop-rails from 2.4.2 to 2.5.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,7 +32,7 @@ Layout/LineLength:
   Description: 'Limit lines to 80 characters.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
   Enabled: false
-  
+
 Layout/MultilineMethodCallBraceLayout:
   Description: 'This cop checks that the closing brace in a method definition is either on the same line as the last method parameter, or a new line.'
   Enabled: false
@@ -229,6 +229,11 @@ Rails/TimeZone:
   Description: 'This cop checks for the use of Time methods without zone.'
   StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#time
                http://danilenko.org/2012/7/6/rails_timezones'
+  Enabled: false
+
+Rails/UniqueValidationWithoutIndex:
+  Description: 'When you define a uniqueness validation in Active Record model, you also should add a unique index for the column.'
+  StyleGuide: 'https://docs.rubocop.org/projects/rails/en/stable/cops_rails/#railsuniquevalidationwithoutindex'
   Enabled: false
 
 # Security Cops ===========================================================================

--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ group :test, :development do
   gem 'rspec-rails'
   gem 'rubocop', '~> 0.80.1'
   gem 'rubocop-performance', '~> 1.5.2'
-  gem 'rubocop-rails', '~> 2.4'
+  gem 'rubocop-rails', '~> 2.5'
   gem 'selenium-webdriver', '~> 3.142'
   gem 'shoulda-matchers', require: false
   gem 'sinatra'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,7 +213,7 @@ GEM
       activerecord (>= 4.2)
       request_store (~> 1.1)
     parallel (1.19.1)
-    parser (2.7.0.4)
+    parser (2.7.0.5)
       ast (~> 2.4.0)
     pg (1.2.2)
     poltergeist (1.18.1)
@@ -312,7 +312,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
-    rubocop-rails (2.4.2)
+    rubocop-rails (2.5.0)
+      activesupport
       rack (>= 1.1)
       rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
@@ -434,7 +435,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop (~> 0.80.1)
   rubocop-performance (~> 1.5.2)
-  rubocop-rails (~> 2.4)
+  rubocop-rails (~> 2.5)
   sass-rails (~> 6.0)
   select2-rails
   selenium-webdriver (~> 3.142)


### PR DESCRIPTION
Moderate security vulnerability found in rubocop-rails 2.4.2.