### PR TITLE
Implementing guard gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -364,6 +364,10 @@ Style/RedundantParentheses:
   Description: 'This cop checks for redundant parentheses.'
   Enabled: false
 
+Style/RegexpLiteral:
+  Description: 'This cop enforces using // or %r around regular expressions.'
+  Enabled: false
+
 Style/RescueStandardError:
   Description: 'This cop checks for rescuing StandardError. There are two supported styles implicit and explicit. This cop will not register an offense if any error other than StandardError is specified.'
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -35,8 +35,11 @@ gem 'will_paginate'
 
 group :development do
   gem 'annotate'
-  gem 'guard-livereload', '>= 2.5.2'
-  gem 'guard-rspec'
+  gem 'guard'
+  gem 'guard-brakeman'
+  gem 'guard-livereload', '~> 2.5', require: false
+  gem 'guard-rspec', require: false
+  gem 'guard-rubocop'
   gem 'rails_db_info'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,10 @@ GEM
       pry (>= 0.9.12)
       shellany (~> 0.0)
       thor (>= 0.18.1)
+    guard-brakeman (0.8.6)
+      brakeman (>= 2.1.1)
+      guard (>= 2.0.0)
+      guard-compat (~> 1.0)
     guard-compat (1.2.1)
     guard-livereload (2.5.2)
       em-websocket (~> 0.5)
@@ -140,6 +144,9 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    guard-rubocop (1.3.0)
+      guard (~> 2.0)
+      rubocop (~> 0.20)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     http_parser.rb (0.6.0)
@@ -412,8 +419,11 @@ DEPENDENCIES
   govuk_frontend_toolkit (~> 7.5)
   govuk_notify_rails
   govuk_template (~> 0.24.1)
-  guard-livereload (>= 2.5.2)
+  guard
+  guard-brakeman
+  guard-livereload (~> 2.5)
   guard-rspec
+  guard-rubocop
   jquery-rails (~> 4.1, >= 4.1.1)
   launchy
   letter_opener

--- a/Guardfile
+++ b/Guardfile
@@ -1,3 +1,21 @@
+guard :rubocop do
+  watch(%r/{.+\.rb$}/)
+  watch(%r{(?:.+/)?\.rubocop(?:_todo)?\.yml$}) { |m| File.dirname(m[0]) }
+end
+
+guard :rspec, cmd: 'bundle exec rspec' do
+  watch(%r{^config/initializers/.+\.rb}) { |_m| 'spec' }
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^app/(.+)\.rb$}) { |m| "spec/#{m[1]}_spec.rb" }
+end
+
+guard :brakeman do
+  watch(%r{^app/.+\.(erb|haml|rhtml|rb)$})
+  watch(%r{^config/.+\.rb$})
+  watch(%r{^lib/.+\.rb$})
+  watch('Gemfile')
+end
+
 guard 'livereload' do
   watch(%r{app/views/.+\.(erb|haml|slim)})
   watch(%r{app/helpers/.+\.rb})
@@ -5,18 +23,4 @@ guard 'livereload' do
   watch(%r{config/locales/.+\.yml})
   # Rails Assets Pipeline
   watch(%r{(app|vendor)(/assets/\w+/(.+\.(scss|js|html|haml))).*}) { |m| "/assets/#{m[3]}" }
-end
-
-# guard :jasmine do
-# watch(%r{^spec/javascripts/.*(?:_s|S)pec\.(coffee|js)$})
-# watch(%r{app/assets/javascripts/(.+?)\.(js\.coffee|js|coffee)(?:\.\w+)*$}) do |m|
-# "spec/javascripts/jasmine/#{ m[1] }_spec.#{ m[2] }"
-# end
-# end
-
-guard :rspec, cmd: 'bundle exec rspec -fd' do
-  watch(%r{^config/initializers/.+\.rb}) { |_m| 'spec' }
-  watch(%r{^spec/.+_spec\.rb$})
-  watch(%r{^app/(.+)\.rb$}) { |m| "spec/#{m[1]}_spec.rb" }
-  watch(%r{^app/interfaces/api/(.+)\.rb$}) { |m| "spec/api/#{m[1]}_spec.rb" }
 end

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ be run be executing the same command with the features folder as argument (i.e.
 `bundle exec rspec features`). Please refer to the [readme](https://github.com/ministryofjustice/parliamentary-questions/tree/dev/features) in the features folder
 for end-to-end tests implementation details.
 
-The Guard gem (https://guardgem.org/) is also installed and can be run via `bundle exec guard`.  Currently the RuboCop, RSpec, Brakeman and LiveReload plugins are setup to run when guard detects a file system modification.
+The Guard gem (https://guardgem.org/) is also installed and can be run via `bundle exec guard`.  Currently the RuboCop, RSpec, Brakeman and LiveReload plugins are setup to run when guard detects a file system modification. To use the LiveReload functionality you will need to install the LiveReload browser extension.
 
 # Emails
 Emails are sent using the [GOVUK Notify service](https://www.notifications.service.gov.uk).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 parliamentary-questions
 =======================
 
-[![Build Status](https://travis-ci.org/ministryofjustice/parliamentary-questions.png?branch=master)](https://travis-ci.org/ministryofjustice/parliamentary-questions)
 [![Code Climate](https://codeclimate.com/github/ministryofjustice/parliamentary-questions/badges/gpa.svg)](https://codeclimate.com/github/ministryofjustice/parliamentary-questions)
 [![CircleCI](https://circleci.com/gh/ministryofjustice/parliamentary-questions.svg?style=svg)](https://circleci.com/gh/ministryofjustice/parliamentary-questions)
 
@@ -93,6 +92,8 @@ Unit tests can be run via `bundle exec rspec`, while end-to-end tests can
 be run be executing the same command with the features folder as argument (i.e.
 `bundle exec rspec features`). Please refer to the [readme](https://github.com/ministryofjustice/parliamentary-questions/tree/dev/features) in the features folder
 for end-to-end tests implementation details.
+
+The Guard gem (https://guardgem.org/) is also installed and can be run via `bundle exec guard`.  Currently the RuboCop, RSpec, Brakeman and LiveReload plugins are setup to run when guard detects a file system modification.
 
 # Emails
 Emails are sent using the [GOVUK Notify service](https://www.notifications.service.gov.uk).


### PR DESCRIPTION
Setup and configured Guard gem with the following plugins:
 - guard-brakeman
 - guard-livereload
 - guard-rspec
 - guard-rubocop

Updated README file to include mention of Guard and removed the Travis build status.

Updated RuboCop exception file to allow Guard to use %r RegEx format in its config file.