### PR TITLE
CT-2889 Fix Rubocop 'content_tag' offence.

### DIFF
--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -8,7 +8,7 @@ module DeviseHelper
   def devise_error_messages!
     return '' if resource.errors.empty?
 
-    messages = resource.errors.full_messages.map { |msg| content_tag(:li, msg) }.join
+    messages = resource.errors.full_messages.map { |msg| tag.li(msg) }.join
     sentence = I18n.t('errors.messages.not_saved',
                       count: resource.errors.count,
                       resource: resource.class.model_name.human.downcase)


### PR DESCRIPTION
CT-2889 Fix Rubocop 'content_tag' offence.
- Replace legacy syntax 'content_tag' command with 'tag'