### PR TITLE
revert-select2-rails-to-v4.0.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -339,7 +339,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    select2-rails (4.0.13)
+    select2-rails (4.0.5)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)


### PR DESCRIPTION
Fix broken styling in Select2 style dropdown lists.  Select2 gem version above 4.0.5 cause this behaviour.  