### PR TITLE
CT-3135 Remove docker layer caching to save cost

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,8 +234,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: /tmp/workspace
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
       - *configure_aws_profile
       - *build_and_push_docker_image
       - persist_to_workspace:


### PR DESCRIPTION
## Description
Remove docker layer caching to save 200 credits per run (may marginally slow down the build, but not a big deal)

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->
BEFORE:
![image](https://user-images.githubusercontent.com/22935203/99433409-61f5b500-2905-11eb-80c7-d3a8e07c1b5e.png)
AFTER:

![image](https://user-images.githubusercontent.com/22935203/99433265-32df4380-2905-11eb-87d6-b5bae6e0332e.png)
(didn't really slow down)

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3135

### Deployment
use circle ci, and make sure it works

### Manual testing instructions
Nothing should change except build time for docker image, and not much. 