### PR TITLE
CT-3318 Stop sending the early bird emails over christmas

### DIFF
--- a/lib/tasks/early_bird.rake
+++ b/lib/tasks/early_bird.rake
@@ -2,7 +2,7 @@ namespace :pqa do
   desc 'Queue Early Bird Emails'
   task :early_bird, [] => :environment do
     if PqaImportRun.ready_for_early_bird
-      if (Time.zone.today < Date.new(2020, 7, 29)) || (Time.zone.today > Date.new(2020, 8, 31))
+      if (Time.zone.today < Date.new(2020, 12, 20)) || (Time.zone.today > Date.new(2021, 1, 4))
         LogStuff.info { 'Early Bird: Preparing to queue early bird mails' }
         service = EarlyBirdReportService.new
         service.notify_early_bird


### PR DESCRIPTION
## Description
The early bird email is not to be sent out from 20.12.2020 to 04.01.2021.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&projectKey=CT&modal=detail&selectedIssue=CT-3318

### Deployment
Nothing special needed for deployment

### Manual testing instructions
Check the date range set in line 5 of lib/tasks/early_bird.rake.  The early bird email is to be suppressed from Sunday the 20th December as questions tabled of Friday need to be sent out on Saturday 19th December.  The process will restart on the 5th January 2021. 
