### PR TITLE
CT-3112 Prevent answering Minister removal from commissioned PQs

### DIFF
--- a/app/views/shared/_minister_selection.html.slim
+++ b/app/views/shared/_minister_selection.html.slim
@@ -1,7 +1,10 @@
 .minister-dropdown.form-group id="answering-minister-form-#{question.try(:id)}"
   label.form-label for="commission_form_minister_id" Answering minister
-  = form.collection_select(:minister_id, Minister.active_or_having_id(question.minister_id), :id, :name_with_inactive_status, {include_blank: true}, { class: 'minister-select required-for-commission'})
-  = render('shared/warning_icon') if minister_warning?(question, question.try(:minister))
+  - if current_page?(dashboard_path)
+    = form.collection_select(:minister_id, Minister.active_or_having_id(question.minister_id), :id, :name_with_inactive_status, {include_blank: true}, { class: 'minister-select required-for-commission'})
+  - else
+    = form.collection_select(:minister_id, Minister.active_or_having_id(question.minister_id), :id, :name_with_inactive_status, { class: 'minister-select required-for-commission'})
+= render('shared/warning_icon') if minister_warning?(question, question.try(:minister))
 
 .minister-dropdown.form-group id="policy-minister-form-#{question.try(:id)}"
   label.form-label for="pq_policy_minister_id" Policy minister (Optional)

--- a/app/views/shared/_minister_selection.html.slim
+++ b/app/views/shared/_minister_selection.html.slim
@@ -1,10 +1,10 @@
 .minister-dropdown.form-group id="answering-minister-form-#{question.try(:id)}"
   label.form-label for="commission_form_minister_id" Answering minister
-  - if current_page?(dashboard_path)
+  - if current_page?(dashboard_path) || current_page?(dashboard_backlog_path)
     = form.collection_select(:minister_id, Minister.active_or_having_id(question.minister_id), :id, :name_with_inactive_status, {include_blank: true}, { class: 'minister-select required-for-commission'})
   - else
     = form.collection_select(:minister_id, Minister.active_or_having_id(question.minister_id), :id, :name_with_inactive_status, { class: 'minister-select required-for-commission'})
-= render('shared/warning_icon') if minister_warning?(question, question.try(:minister))
+  = render('shared/warning_icon') if minister_warning?(question, question.try(:minister))
 
 .minister-dropdown.form-group id="policy-minister-form-#{question.try(:id)}"
   label.form-label for="pq_policy_minister_id" Policy minister (Optional)


### PR DESCRIPTION
Add blank first line in the answering Minister dropdown when displayed on the Dashboard page only.

## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [X] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->
Currently, all 'in progress' questions can have the answering Minister changed via a dropdown list on the 'In progress' page 'PQ commission' tab.  This dropdown list has a blank first option which can be accidentally chosen.  This null value breaks subsequent attempts to render the 'In progress' page.
 
![Commissioned-PQ-answering-Minister-dropdown(before)](https://user-images.githubusercontent.com/6988369/106011190-1fddb200-60b2-11eb-9392-141a2c0bc436.png)

The blank dropdown option makes no sense in the context of a commissioned question.  Therefore it should be removed.

![Commissioned-PQ-answering-Minister-dropdown(after)](https://user-images.githubusercontent.com/6988369/106011252-3126be80-60b2-11eb-9790-2d041e62250b.png)

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&projectKey=CT&modal=detail&selectedIssue=CT-3112

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->


### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
1) Commision a question on the dashboard, setting yourself as the Action Officer.
2) Accept the PQ from the link found in the email the system sent you. 
    OR
    Manually alter your development database.  Set the PQs 'State' to 'draft_pending'.
3) Goto the 'In progress' page.
4) Click on the question ID link.
5) Click on the 'PQ commission' tab.
6) The 'Answering minister' dropdown will not have a blank line as the first option.
