### PR TITLE
CT-3419 Add reusable alert banner for RDS upgrade

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -45,4 +45,5 @@
 @import "moj/forms";
 @import "moj/navigation";
 @import "vendor/bootstrap";
+@import "moj/alert-banner";
 @import "pq";

--- a/app/assets/stylesheets/moj/_alert-banner
+++ b/app/assets/stylesheets/moj/_alert-banner
@@ -1,0 +1,24 @@
+.alert-banner {
+  @extend %site-width-container;
+  border: 4px solid $govuk-blue;
+  padding: 2rem 2rem 1rem;
+  margin-top: 2em;
+  margin-bottom: 2em;
+  box-sizing: border-box;
+  position: relative;
+
+  &__icon {
+    color: $govuk-blue;
+    position: absolute;
+    left: 2rem;
+    top: 2rem;
+  }
+
+  &__info {
+    padding: 5px 0 0 55px;
+
+    @include media(tablet) {
+      font-size: 19px;
+    }
+  }
+}

--- a/app/views/layouts/_banner.html.slim
+++ b/app/views/layouts/_banner.html.slim
@@ -1,0 +1,5 @@
+.alert-banner
+  svg.alert-banner__icon fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="40" width="40"
+    path d="M13.7,18.5h-2.4v-2.4h2.4V18.5z  M12.5,13.7c-0.7,0-1.2-0.5-1.2-1.2V7.7c0-0.7,0.5-1.2,1.2-1.2s1.2,0.5,1.2,1.2v4.8
+C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S19.1,0.5,12.5,0.5z" 
+  p.alert-banner__info This service will be down for essential maintenance between 12pm and 2pm on Monday 15th February. You will not have access during this period. Please contact <a href="mailto:pqsupport@digital.justice.gov.uk">pqsupport@digital.justice.gov.uk</a> if you have any queries. Apologies for the inconvenience.

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -34,7 +34,7 @@
       .staging_banner
         | This is not the live Parliamentary Questions Tracker environment
 
-
+    = render partial: "layouts/banner"
     = render partial: "shared/navigation"
     .container
       .content-inner


### PR DESCRIPTION
## Description
Add a banner that can be re-used if needed for PQ Tracker RDS upgrade
Note: It seems we're not using en.yml for the text on PQ Tracker, so sticking with that now. But at some point I may tidy that up.


## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->
![image](https://user-images.githubusercontent.com/22935203/107515525-0a34b600-6ba3-11eb-9e18-bfe656237a43.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3419

### Deployment
n/a

### Manual testing instructions
Nice banner should show