### PR TITLE
Ct 3495 fix deprecation warnings

### DIFF
--- a/app/controllers/ao_token_filter.rb
+++ b/app/controllers/ao_token_filter.rb
@@ -28,7 +28,7 @@ class AOTokenFilter
     log_error(token_state, params)
 
     controller.update_page_title 'Unauthorised (401)'
-    controller.render file: "shared/token_#{token_state}.html.slim", status: :unauthorized
+    controller.render "shared/token_#{token_state}.html.slim", status: :unauthorized
   end
 
   def self.log_error(token_state, params)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -80,7 +80,6 @@ class ApplicationController < ActionController::Base
 
   def show_error_page_and_increment_statsd(err_number, exception = nil)
     $statsd.increment("#{StatsHelper::PAGES_ERRORS}.#{err_number}")
-    # var errorPagePath = "public/#{err_number}"
     respond_to do |format|
       format.html { render file: "public/#{err_number}.html", status: err_number }
       format.all  { render nothing: true, status: err_number }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -80,8 +80,9 @@ class ApplicationController < ActionController::Base
 
   def show_error_page_and_increment_statsd(err_number, exception = nil)
     $statsd.increment("#{StatsHelper::PAGES_ERRORS}.#{err_number}")
+    # var errorPagePath = "public/#{err_number}"
     respond_to do |format|
-      format.html { render file: "public/#{err_number}", status: err_number }
+      format.html { render file: "public/#{err_number}.html", status: err_number }
       format.all  { render nothing: true, status: err_number }
     end
     backtrace = exception.nil? ? nil : exception.backtrace

--- a/lib/pq_statistics/percent_on_time.rb
+++ b/lib/pq_statistics/percent_on_time.rb
@@ -34,7 +34,8 @@ module PqStatistics
 
     def pq_data(dates)
       Pq.answered
-        .where.not(answer_submitted: nil, date_for_answer: nil)
+        .where.not(answer_submitted: nil)
+        .where.not(date_for_answer: nil)
         .where('answer_submitted > ?', dates.last)
         .pluck(:answer_submitted, :date_for_answer)
     end


### PR DESCRIPTION
## Description
When running ‘rspec features’ tests the following warnings are output:

`DEPRECATION WARNING: render file: should be given the absolute path to a file (called from log_and_redirect at /Users/nickpreddy/Desktop/Repositories/parliamentary-questions/app/controllers/ao_token_filter.rb:31)`

`DEPRECATION WARNING: render file: should be given the absolute path to a file (called from block (2 levels) in show_error_page_and_increment_statsd at /Users/nickpreddy/Desktop/Repositories/parliamentary-questions/app/controllers/application_controller.rb:84)`

and

`DEPRECATION WARNING: NOT conditions will no longer behave as NOR in Rails 6.1. To continue using NOR conditions, NOT each condition individually (.where.not(:answer_submitted => ...).where.not(:date_for_answer => ...)). (called from pq_data at /Users/nickpreddy/Desktop/Repositories/parliamentary-questions/lib/pq_statistics/percent_on_time.rb:37)`

the render file: and NOT conditions need to be addressed in lew of upgrading to Rails 6.1.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots

### Related JIRA tickets
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&projectKey=CT&modal=detail&selectedIssue=CT-3495

### Deployment


### Manual testing instructions
Running the Rspec feature tests should output no errors or deprecation warnings.
