### PR TITLE
CT-3562 Update mimemagic gem to v0.3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,7 +216,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)


### PR DESCRIPTION
## Description
RE: https://github.com/rails/rails/issues/41750

The application will not build due to all versions of mimemagic gem below 0.3.6 being pulled by the maintainer.

PQs dependency is currently rails (6.0.3.4)/activestorage (6.0.3.4)/marcel (0.3.3)/ mimemagic (0.3.5)

The difference between mimemagic 0.3.5 & 0.3.6 is a change in from MIT to GPL v2.0 licenses.

Upgrading 0.3.6 fixes build problems.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&projectKey=CT&selectedIssue=CT-3562

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Please test the happy path (Has been deployed to Dev and Staging).
