### PR TITLE
CT-3601 - Suppress the early bird email during prorogue period 

### DIFF
--- a/lib/tasks/early_bird.rake
+++ b/lib/tasks/early_bird.rake
@@ -2,7 +2,7 @@ namespace :pqa do
   desc 'Queue Early Bird Emails'
   task :early_bird, [] => :environment do
     if PqaImportRun.ready_for_early_bird
-      if (Time.zone.today < Date.new(2021, 3, 27)) || (Time.zone.today > Date.new(2021, 4, 13))
+      if (Time.zone.today < Date.new(2021, 5, 4)) || (Time.zone.today > Date.new(2021, 5, 11))
         LogStuff.info { 'Early Bird: Preparing to queue early bird mails' }
         service = EarlyBirdReportService.new
         service.notify_early_bird


### PR DESCRIPTION
## Description
Set early bird email to stop on 4th May 2021, resuming on the 12th May 2021.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&projectKey=CT&modal=detail&selectedIssue=CT-3601

### Deployment
Deployed to both Dev and Staging environments for testing

### Manual testing instructions
Please test the 'happy' path for any obvious issues.
