### PR TITLE
CT-3549 & CT-3562 - Remove controller level force ssl option.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,10 @@ Layout/SpaceAroundOperators:
   Description: 'Checks that operators have space around them, except for ** which should not have surrounding space.'
   Enabled: false
 
+Layout/SpaceInLambdaLiteral:
+  Description: 'This cop checks for spaces between -> and opening parameter parenthesis (() in lambda literals.'
+  Enabled: false
+
 # Lint Cops ===============================================================================
 
 Lint/AmbiguousBlockAssociation:
@@ -401,6 +405,10 @@ Style/Send:
 
 Style/SingleLineBlockParams:
   Description: 'This cop checks whether the block parameters of a single-line method accepting a block match the names specified via configuration.'
+  Enabled: false
+
+Style/StabbyLambdaParentheses:
+  Description: 'Check for parentheses around stabby lambda arguments. There are two different styles. Defaults to require_parentheses.'
   Enabled: false
 
 Style/StringHashKeys:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,10 +45,6 @@ Layout/SpaceAroundOperators:
   Description: 'Checks that operators have space around them, except for ** which should not have surrounding space.'
   Enabled: false
 
-Layout/SpaceInLambdaLiteral:
-  Description: 'This cop checks for spaces between -> and opening parameter parenthesis (() in lambda literals.'
-  Enabled: false
-
 # Lint Cops ===============================================================================
 
 Lint/AmbiguousBlockAssociation:
@@ -405,10 +401,6 @@ Style/Send:
 
 Style/SingleLineBlockParams:
   Description: 'This cop checks whether the block parameters of a single-line method accepting a block match the names specified via configuration.'
-  Enabled: false
-
-Style/StabbyLambdaParentheses:
-  Description: 'Check for parentheses around stabby lambda arguments. There are two different styles. Defaults to require_parentheses.'
   Enabled: false
 
 Style/StringHashKeys:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,12 +6,6 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-  # SSL Production Config
-  if Rails.env.production? && !HostEnv.is_dev?
-    # Reset session when hitting excepted routes so as not to leak cookie
-    before_action :reset_session, if: :ssl_excepted?
-  end
-
   if Rails.env.production? || ENV['TRAP_ERRORS_IN_TEST'] == '1'
     rescue_from StandardError do |exception|
       if exception.is_a?(ActiveRecord::RecordNotFound)
@@ -55,12 +49,6 @@ class ApplicationController < ActionController::Base
   end
 
   protected
-
-  def ssl_excepted?
-    Settings.excepted_from_ssl.any? do |excepted_path|
-      !!(request.fullpath =~ Regexp.new(excepted_path))
-    end
-  end
 
   def set_page_title
     @page_title = 'MOJ Parliamentary Questions'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,12 +7,12 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   # SSL Production Config
-  if Rails.env.production? && !HostEnv.is_dev?
-    # Force SSL except in excepted routes
-    force_ssl unless: :ssl_excepted?
-    # Reset session when hitting excepted routes so as not to leak cookie
-    before_action :reset_session, if: :ssl_excepted?
-  end
+  # if Rails.env.production? && !HostEnv.is_dev?
+  #   # Force SSL except in excepted routes
+  #   force_ssl unless: :ssl_excepted?
+  #   # Reset session when hitting excepted routes so as not to leak cookie
+  #   before_action :reset_session, if: :ssl_excepted?
+  # end
 
   if Rails.env.production? || ENV['TRAP_ERRORS_IN_TEST'] == '1'
     rescue_from StandardError do |exception|
@@ -58,11 +58,11 @@ class ApplicationController < ActionController::Base
 
   protected
 
-  def ssl_excepted?
-    Settings.excepted_from_ssl.any? do |excepted_path|
-      !!(request.fullpath =~ Regexp.new(excepted_path))
-    end
-  end
+  # def ssl_excepted?
+  #   Settings.excepted_from_ssl.any? do |excepted_path|
+  #     !!(request.fullpath =~ Regexp.new(excepted_path))
+  #   end
+  # end
 
   def set_page_title
     @page_title = 'MOJ Parliamentary Questions'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,12 +7,10 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   # SSL Production Config
-  # if Rails.env.production? && !HostEnv.is_dev?
-  #   # Force SSL except in excepted routes
-  #   force_ssl unless: :ssl_excepted?
-  #   # Reset session when hitting excepted routes so as not to leak cookie
-  #   before_action :reset_session, if: :ssl_excepted?
-  # end
+  if Rails.env.production? && !HostEnv.is_dev?
+    # Reset session when hitting excepted routes so as not to leak cookie
+    before_action :reset_session, if: :ssl_excepted?
+  end
 
   if Rails.env.production? || ENV['TRAP_ERRORS_IN_TEST'] == '1'
     rescue_from StandardError do |exception|
@@ -58,11 +56,11 @@ class ApplicationController < ActionController::Base
 
   protected
 
-  # def ssl_excepted?
-  #   Settings.excepted_from_ssl.any? do |excepted_path|
-  #     !!(request.fullpath =~ Regexp.new(excepted_path))
-  #   end
-  # end
+  def ssl_excepted?
+    Settings.excepted_from_ssl.any? do |excepted_path|
+      !!(request.fullpath =~ Regexp.new(excepted_path))
+    end
+  end
 
   def set_page_title
     @page_title = 'MOJ Parliamentary Questions'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,6 +45,10 @@ ParliamentaryQuestions::Application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
+  # Exclude SSL on ping.json path calls
+  # SSL on this path may break calls when app is behind a load balancer.
+  config.ssl_options = { redirect: { exclude: -> request { request.path =~ /ping.json/ } } }
+
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,8 +46,8 @@ ParliamentaryQuestions::Application.configure do
   config.force_ssl = true
 
   # Exclude SSL on Healthcheck and ping.json calls
-  config.ssl_options = { redirect: { exclude: -> request { request.path.include? '/ping.json/' } } }
-  config.ssl_options = { redirect: { exclude: -> request { request.path.include? '/healthcheck/' } } }
+  config.ssl_options = { redirect: { exclude: -> request { request.path.include? '/ping.json' } } }
+  config.ssl_options = { redirect: { exclude: -> request { request.path.include? '/healthcheck' } } }
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,10 +45,6 @@ ParliamentaryQuestions::Application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Exclude SSL on Healthcheck and ping.json calls
-  config.ssl_options = { redirect: { exclude: -> request { request.path.include? '/ping.json' } } }
-  config.ssl_options = { redirect: { exclude: -> request { request.path.include? '/healthcheck' } } }
-
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,7 +43,7 @@ ParliamentaryQuestions::Application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,9 +45,9 @@ ParliamentaryQuestions::Application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Exclude SSL on ping.json path calls
-  # SSL on this path may break calls when app is behind a load balancer.
-  config.ssl_options = { redirect: { exclude: -> request { request.path =~ /ping.json/ } } }
+  # Exclude SSL on Healthcheck and ping.json calls
+  config.ssl_options = { redirect: { exclude: -> request { request.path.include? '/ping.json/' } } }
+  config.ssl_options = { redirect: { exclude: -> request { request.path.include? '/healthcheck/' } } }
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -45,6 +45,10 @@ ParliamentaryQuestions::Application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
+  # Exclude SSL on Healthcheck and ping.json calls
+  config.ssl_options = { redirect: { exclude: -> request { request.path.include? '/ping.json/' } } }
+  config.ssl_options = { redirect: { exclude: -> request { request.path.include? '/healthcheck/' } } }
+
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -46,8 +46,8 @@ ParliamentaryQuestions::Application.configure do
   config.force_ssl = true
 
   # Exclude SSL on Healthcheck and ping.json calls
-  config.ssl_options = { redirect: { exclude: -> request { request.path.include? '/ping.json/' } } }
-  config.ssl_options = { redirect: { exclude: -> request { request.path.include? '/healthcheck/' } } }
+  config.ssl_options = { redirect: { exclude: -> request { request.path.include? '/ping.json' } } }
+  config.ssl_options = { redirect: { exclude: -> request { request.path.include? '/healthcheck' } } }
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -45,10 +45,6 @@ ParliamentaryQuestions::Application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Exclude SSL on Healthcheck and ping.json calls
-  config.ssl_options = { redirect: { exclude: -> request { request.path.include? '/ping.json' } } }
-  config.ssl_options = { redirect: { exclude: -> request { request.path.include? '/healthcheck' } } }
-
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -43,7 +43,7 @@ ParliamentaryQuestions::Application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,8 +10,8 @@ parliamentary_team_email: 6914dbfe-4cbb-46dc-aaac-c4be561c8e72
 tech_support_email: 0cdb6fb9-ded7-4fd6-b878-2c431bcb924f
 govuk_notify_api_key: refer-to-instructions-on-how-to-add-key-to-env-variables
 
-# excepted_from_ssl:
-#   - ping.json
+excepted_from_ssl:
+  - ping.json
 
 mail_worker:
   pid_filepath: '/tmp/mail_worker.pid'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,8 +10,8 @@ parliamentary_team_email: 6914dbfe-4cbb-46dc-aaac-c4be561c8e72
 tech_support_email: 0cdb6fb9-ded7-4fd6-b878-2c431bcb924f
 govuk_notify_api_key: refer-to-instructions-on-how-to-add-key-to-env-variables
 
-excepted_from_ssl:
-  - ping.json
+# excepted_from_ssl:
+#   - ping.json
 
 mail_worker:
   pid_filepath: '/tmp/mail_worker.pid'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,9 +10,6 @@ parliamentary_team_email: 6914dbfe-4cbb-46dc-aaac-c4be561c8e72
 tech_support_email: 0cdb6fb9-ded7-4fd6-b878-2c431bcb924f
 govuk_notify_api_key: refer-to-instructions-on-how-to-add-key-to-env-variables
 
-excepted_from_ssl:
-  - ping.json
-
 mail_worker:
   pid_filepath: '/tmp/mail_worker.pid'
   max_fail_count: 15

--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -65,10 +65,6 @@ module Settings
     ENV.fetch('GA_TRACKER_ID', DEFAULT_GA_TRACKER_ID)
   end
 
-  def excepted_from_ssl
-    @h['excepted_from_ssl']
-  end
-
   def healthcheck_pqa_api_interval
     @h['healthcheck_pqa_api_interval']
   end

--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -65,9 +65,9 @@ module Settings
     ENV.fetch('GA_TRACKER_ID', DEFAULT_GA_TRACKER_ID)
   end
 
-  def excepted_from_ssl
-    @h['excepted_from_ssl']
-  end
+  # def excepted_from_ssl
+  #   @h['excepted_from_ssl']
+  # end
 
   def healthcheck_pqa_api_interval
     @h['healthcheck_pqa_api_interval']

--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -65,9 +65,9 @@ module Settings
     ENV.fetch('GA_TRACKER_ID', DEFAULT_GA_TRACKER_ID)
   end
 
-  # def excepted_from_ssl
-  #   @h['excepted_from_ssl']
-  # end
+  def excepted_from_ssl
+    @h['excepted_from_ssl']
+  end
 
   def healthcheck_pqa_api_interval
     @h['healthcheck_pqa_api_interval']

--- a/spec/models/settings_spec.rb
+++ b/spec/models/settings_spec.rb
@@ -68,11 +68,11 @@ describe Settings do
       end
     end
 
-    describe '.excepted_from_ssl' do
-      it 'should return an array from the file' do
-        expect(Settings.excepted_from_ssl).to eq ['ping.json']
-      end
-    end
+    # describe '.excepted_from_ssl' do
+    #   it 'should return an array from the file' do
+    #     expect(Settings.excepted_from_ssl).to eq ['ping.json']
+    #   end
+    # end
 
     describe '.key_metric_threshold' do
       it 'should return the value from the file' do

--- a/spec/models/settings_spec.rb
+++ b/spec/models/settings_spec.rb
@@ -68,12 +68,6 @@ describe Settings do
       end
     end
 
-    describe '.excepted_from_ssl' do
-      it 'should return an array from the file' do
-        expect(Settings.excepted_from_ssl).to eq ['ping.json']
-      end
-    end
-
     describe '.key_metric_threshold' do
       it 'should return the value from the file' do
         expect(Settings.key_metric_threshold).to eq 0.5

--- a/spec/models/settings_spec.rb
+++ b/spec/models/settings_spec.rb
@@ -68,11 +68,11 @@ describe Settings do
       end
     end
 
-    # describe '.excepted_from_ssl' do
-    #   it 'should return an array from the file' do
-    #     expect(Settings.excepted_from_ssl).to eq ['ping.json']
-    #   end
-    # end
+    describe '.excepted_from_ssl' do
+      it 'should return an array from the file' do
+        expect(Settings.excepted_from_ssl).to eq ['ping.json']
+      end
+    end
 
     describe '.key_metric_threshold' do
       it 'should return the value from the file' do


### PR DESCRIPTION
## Description
Removed used of depricated force_SSL at the controller level.  SSL now enforced from environment config files.  
Part of tickets CT-3549 & CT-3562

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Check 'happy' path in staging environment.
