### PR TITLE
CT-3602 Prefix 2019-21 Parliamentary session questions with a '£'

### DIFF
--- a/lib/tasks/bugfix.rake
+++ b/lib/tasks/bugfix.rake
@@ -50,9 +50,9 @@ namespace :bugfix do
   desc 'Prefix uins for previous session'
   task prefix_uins: :environment do
     puts "Number of non-prefixed uins #{(
-    Pq.where.not(("uin SIMILAR TO '(#|[ESCAPE *]|$|^)%'")).count)} "
-    Pq.where.not(("uin SIMILAR TO '(#|[ESCAPE *]|$|^)%'")).update_all("uin='~'||uin")
-    puts "Number of uins with ~ prefix #{(Pq.where('uin like ?', '~%').count)} "
-    puts "Post-update: Number of non-prefixed uins #{(Pq.where.not(("uin SIMILAR TO '(#|[ESCAPE *]|$|^|~)%'")).count)} "
+    Pq.where.not(("uin SIMILAR TO '(#|[ESCAPE *]|$|^|~)%'")).count)} "
+    Pq.where.not(("uin SIMILAR TO '(#|[ESCAPE *]|$|^|~)%'")).update_all("uin='£'||uin")
+    puts "Number of uins with £ prefix #{(Pq.where('uin like ?', '£%').count)} "
+    puts "Post-update: Number of non-prefixed uins #{(Pq.where.not(("uin SIMILAR TO '(#|[ESCAPE *]|$|^|~|£)%'")).count)} "
   end
 end


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
Prefix 2019-21 Parliamentary session questions with a '£'

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&projectKey=CT&modal=detail&selectedIssue=CT-3602

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->
This updated rake task has been deployed and actioned on both Dev and Staging environments

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
Please check the 'happy path' for any obvious glitches.  A  questions in both environments will be prefixed with a '£' character only.