### PR TITLE
CT-3631 Fix early bird email malformed link URL

### DIFF
--- a/app/mailers/notify_pq_mailer.rb
+++ b/app/mailers/notify_pq_mailer.rb
@@ -87,7 +87,7 @@ class NotifyPqMailer < GovukNotifyRails::Mailer
     set_template('e0700ef3-8a63-4041-ae97-323a1e62272f')
     set_personalisation(
       formatted_date: (Time.zone.today.strftime '%d/%m/%Y'),
-      early_bird_link: early_bird_dashboard_url(token: token, entity: entity, protocol: 'https'),
+      early_bird_link: early_bird_dashboard_url(host: ActionMailer::Base.default_url_options[:host], token: token, entity: entity, protocol: 'https'),
       reply_to_email: Settings.mail_reply_to
     )
     set_email_reply_to(Settings.parliamentary_team_email)

--- a/app/services/early_bird_report_service.rb
+++ b/app/services/early_bird_report_service.rb
@@ -20,6 +20,7 @@ class EarlyBirdReportService
       LogStuff.tag(:mailer_early_bird) do
         LogStuff.info { "Early bird email to pqtest@digital.justice.gov.uk} (name early_bird) [CCd to #{recipients.join(';')}]" }
         NotifyPqMailer.early_bird_email(email: recipient, token: token, entity: entity).deliver_now
+        sleep(0.5)
       end
     end
     token


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
From time to time customers will receive an early bird email with a malformed URL:

    https://100.101.185.223/early_bird/...

The hostname is being replaced with an IP number.  The correct URL format is:

    https://trackparliamentaryquestions.service.gov.uk/early_bird/...

To fix this we explicitly add the environment hostname to the link definition.  As there is no queue when firing emails to a list of customers, a half second delay has been temporarily introduced after calling the delivery method.  

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&projectKey=CT&modal=detail&selectedIssue=CT-3631

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->
This branch has been deployed to both Dev and Staging environments

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
This branch has been tested once by firing the early bird from staging to fellow developers.

To do this you need to log into Staging environment, then go to Settings / Early bird list.  Edit each of the users in this list to make sure their correct email address is saved (nightly run smoke tests edit them to make them unusable).  Finally click on the 'Send early bird info' button above the list of users (Double check your are in Staging not Production!) .  All the devs in the sending list will the receive the email.  

Please also check the 'Happy path' for any irregularities.
