### PR TITLE
CT-3650 Replace ActiveRecord::Base.connected?

### DIFF
--- a/lib/health_check/database.rb
+++ b/lib/health_check/database.rb
@@ -13,7 +13,7 @@ module HealthCheck
 
     def available?
       begin
-        result = ActiveRecord::Base.connected?
+        result = ActiveRecord::Base.connection.active?
         log_error unless result == true
       rescue => e
         log_unknown_error(e)

--- a/spec/health_check/database_spec.rb
+++ b/spec/health_check/database_spec.rb
@@ -9,7 +9,7 @@ describe HealthCheck::Database do
     end
 
     it 'returns false if the database is not available' do
-      allow(ActiveRecord::Base).to receive(:connected?).and_return(false)
+      allow(ActiveRecord::Base.connection).to receive(:active?).and_return(false)
       expect(db).not_to be_available
     end
   end
@@ -28,7 +28,7 @@ describe HealthCheck::Database do
 
   context '#error_messages' do
     it 'returns the exception messages if there is an error accessing the database' do
-      allow(ActiveRecord::Base).to receive(:connected?).and_return(false)
+      allow(ActiveRecord::Base.connection).to receive(:active?).and_return(false)
       db.available?
 
       expect(db.error_messages).to eq([
@@ -38,7 +38,7 @@ describe HealthCheck::Database do
     end
 
     it 'returns an error an backtrace for errors not specific to a component' do
-      allow(ActiveRecord::Base).to receive(:connected?).and_raise(StandardError)
+      allow(ActiveRecord::Base.connection).to receive(:active?).and_raise(StandardError)
       db.available?
 
       expect(db.error_messages.first).to match(/Error: StandardError\nDetails/)


### PR DESCRIPTION

## Description
Replace ActiveRecord::Base.connected? 

This method no longer reliably returns "true" when asking if the db is visible. If there has been no query within a certain timeframe, the connection is released and this method returns false although
any query will reconnect

We can use the newer ActiveRecord::Base.connection.active? which doesn't have this behaviour and returns true if the db
can be accessed, not "is connected"


## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
n/a

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3650

### Deployment
n/a

### Manual testing instructions
n/a
