### PR TITLE
CT-3650 investigate pod restarts and instability 

### DIFF
--- a/app/controllers/health_check_controller.rb
+++ b/app/controllers/health_check_controller.rb
@@ -2,14 +2,12 @@ class HealthCheckController < ApplicationController
   respond_to :json
 
   def index
-    Rails.logger.silence do
-      report = HealthCheckService.new.report
+    report = HealthCheckService.new.report
 
-      if report.status == '200'
-        render(json: report)
-      else
-        render(json: report, status: '500')
-      end
+    if report.status == '200'
+      render(json: report)
+    else
+      render(json: report, status: '500')
     end
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,4 +1,4 @@
-if Rails.env.production? && ENV['SENTRY_DSN'].present?
+if ENV['SENTRY_DSN'].present?
   Sentry.init do |config|
     config.dsn = ENV['SENTRY_DSN']
     config.breadcrumbs_logger = [:active_support_logger]

--- a/k8s-deploy/development/deployment.yaml
+++ b/k8s-deploy/development/deployment.yaml
@@ -97,7 +97,7 @@ spec:
                 name: pq-secrets
           readinessProbe:
             httpGet:
-              path: /healthcheck
+              path: /ping.json
               port: 3000
               httpHeaders:
                 - name: X-Forwarded-Proto
@@ -106,9 +106,10 @@ spec:
                   value: "on"
             initialDelaySeconds: 40
             periodSeconds: 60
+            timeoutSeconds: 2
           livenessProbe:
             httpGet:
-              path: /healthcheck
+              path: /ping.json
               port: 3000
               httpHeaders:
                 - name: X-Forwarded-Proto
@@ -117,6 +118,7 @@ spec:
                   value: "on"
             initialDelaySeconds: 40
             periodSeconds: 60
+            timeoutSeconds: 2
           imagePullPolicy: Always
           name: parliamentary-questions-rails-app
           ports:

--- a/k8s-deploy/production/deployment.yaml
+++ b/k8s-deploy/production/deployment.yaml
@@ -92,7 +92,7 @@ spec:
                 name: pq-secrets
           readinessProbe:
             httpGet:
-              path: /healthcheck
+              path: /ping.json
               port: 3000
               httpHeaders:
                 - name: X-Forwarded-Proto
@@ -101,9 +101,10 @@ spec:
                   value: "on"
             initialDelaySeconds: 40
             periodSeconds: 60
+            timeoutSeconds: 2
           livenessProbe:
             httpGet:
-              path: /healthcheck
+              path: /ping.json
               port: 3000
               httpHeaders:
                 - name: X-Forwarded-Proto
@@ -112,6 +113,7 @@ spec:
                   value: "on"
             initialDelaySeconds: 40
             periodSeconds: 60
+            timeoutSeconds: 2
           imagePullPolicy: Always
           name: parliamentary-questions-rails-app
           ports:

--- a/k8s-deploy/staging/deployment.yaml
+++ b/k8s-deploy/staging/deployment.yaml
@@ -97,7 +97,7 @@ spec:
                 name: pq-secrets
           readinessProbe:
             httpGet:
-              path: /healthcheck
+              path: /ping.json
               port: 3000
               httpHeaders:
                 - name: X-Forwarded-Proto
@@ -106,10 +106,10 @@ spec:
                   value: "on"
             initialDelaySeconds: 40
             periodSeconds: 60
-            timeoutSeconds: 10
+            timeoutSeconds: 2
           livenessProbe:
             httpGet:
-              path: /healthcheck
+              path: /ping.json
               port: 3000
               httpHeaders:
                 - name: X-Forwarded-Proto
@@ -118,7 +118,7 @@ spec:
                   value: "on"
             initialDelaySeconds: 40
             periodSeconds: 60
-            timeoutSeconds: 10
+            timeoutSeconds: 2
           imagePullPolicy: Always
           name: parliamentary-questions-rails-app
           ports:

--- a/k8s-deploy/staging/deployment.yaml
+++ b/k8s-deploy/staging/deployment.yaml
@@ -106,6 +106,7 @@ spec:
                   value: "on"
             initialDelaySeconds: 40
             periodSeconds: 60
+            timeoutSeconds: 10
           livenessProbe:
             httpGet:
               path: /healthcheck
@@ -117,6 +118,7 @@ spec:
                   value: "on"
             initialDelaySeconds: 40
             periodSeconds: 60
+            timeoutSeconds: 10
           imagePullPolicy: Always
           name: parliamentary-questions-rails-app
           ports:


### PR DESCRIPTION
## Description
We're seeing high levels of pod restarts on all namespaces but particularly on production. One reason is that the liveness probe uses the `/healthcheck` endpoint which has dependencies on multiple external services responding over http, and the default timeout for Kubernetes probes is just 1s - so it fails regularly although the remote services are there (false positive), and if there are three in succession the pod gets restarted for no valid reason.

This PR changes the liveness and readiness probe endpoints to `/ping.json` to bring it into line with other services and for practical reasons. One reason is that if the PQ API is absent for any reason, this is _not_ a good reason to take down the PQ service. We do want to get alerted to it, which will happen because the Pingdom check will fail. Another key reason is that 
a) the database in practice never goes away and 
b) if it did go away, and we disabled all the pods from the namespace (that's the implication of pointing the liveness probe at a failing endpoint) we would lose the ability to easily see what the error actually is. 

We also set the timeoutValue explicitly to help future developers understand this constraint, as the 1s default was not obvious. 

We also make a couple changes to improve logging and alerting by no longer silencing the healtcheck endpoint and enabling Sentry reporting on staging and development as well.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3650

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
