### PR TITLE
CT-2886 using the host from env to fix the  ipaddress issue

### DIFF
--- a/app/mailers/notify_pq_mailer.rb
+++ b/app/mailers/notify_pq_mailer.rb
@@ -54,7 +54,7 @@ class NotifyPqMailer < GovukNotifyRails::Mailer
       answer_by: pq.minister&.name || '',
       internal_deadline: internal_deadline_text(pq) || '',
       date_to_parliament: date_to_parliament_text(pq) || '',
-      pq_link: assignment_url(uin: pq.uin, token: token, entity: entity, protocol: 'https'),
+      pq_link: assignment_url(host: ActionMailer::Base.default_url_options[:host], uin: pq.uin, token: token, entity: entity, protocol: 'https'),
       mail_reply_to: Settings.mail_reply_to
     )
     set_email_reply_to(Settings.parliamentary_team_email)


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
This PR is to make sure the host in the email is the one we intent to,  in general,  the host shouldn't need to be specified,  but somehow in some cases, the rails somehow couldn't decide what the host is,  instead, it uses the ip address from the pod in the cluster,  I spent some time to think about it, not quite sure how happened, it may related to the frequent-restarts or something else down to the environment outside app itself. 

The way used for this PR make sure the host is the one we configured ( which mean it may differ from the one hosted), but I would think it shouldn't cause any downsides as long as we always set  the url correctly in each env

No  tests needed 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&modal=detail&selectedIssue=CT-2886
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
