### PR TITLE
CT-3692 Remove :admin key in param to stop Brakeman warning

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,6 +27,6 @@ class UsersController < ApplicationController
   protected
 
   def user_params
-    params.require(:user).permit(:email, :admin, :name, :roles, :deleted)
+    params.require(:user).permit(:email, :name, :roles, :deleted)
   end
 end


### PR DESCRIPTION
The issue that brakeman was complaining about is that admin was being allowed in .permit in the users_controller.rb. See why this can be an issue here: https://brakemanscanner.org/docs/warning_types/mass_assignment/ 

I think this was a mistake in that these params are only used on to update a user and the form that controls this has no :admin value to return. A completely filled in form has the following keys returned:

"user"=>{ "name"=>"New OldName",
                 "email"=>"admin@something.com",
                 "roles"=>"PQUSER",
                 "deleted"=>"0"}

Similarly the models in the app have no 'admin' flag at all.

I think this was just an oversight or left over from an earlier iteration of the page.

I have removed the :admin key here, and this brakeman warning no longer occurs


## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
[CT-3692](https://dsdmoj.atlassian.net/browse/CT-3692)

### Manual testing instructions
- Please check my thinking here 👍 
