### PR TITLE
CT-3812 Make reports tab keyboard focusable

### DIFF
--- a/app/assets/stylesheets/pq.scss
+++ b/app/assets/stylesheets/pq.scss
@@ -104,7 +104,7 @@ label {
 .nav-pills > li.active > a,
 .nav-pills > li.active > a:hover,
 .nav-pills > li.active > a:focus,
-.dropdown-menu li a:hover { background-color: $yellow; }
+.dropdown-menu li a:hover, .dropdown-menu li a:focus { background-color: $yellow;  }
 
 .block-label:hover, .js-enabled .selected { border-color: $text-colour; }
 .js-enabled .selected { background-color: $page-colour; }

--- a/app/assets/stylesheets/vendor/bootstrap.scss
+++ b/app/assets/stylesheets/vendor/bootstrap.scss
@@ -3226,10 +3226,6 @@ input[type="button"].btn-block {
   position: relative;
 }
 
-.dropdown-toggle:focus {
-  outline: 0;
-}
-
 .dropdown-menu {
   position: absolute;
   top: 100%;
@@ -3306,10 +3302,6 @@ input[type="button"].btn-block {
 
 .open > .dropdown-menu {
   display: block;
-}
-
-.open > a {
-  outline: 0;
 }
 
 .dropdown-header {

--- a/app/views/shared/_navigation.html.slim
+++ b/app/views/shared/_navigation.html.slim
@@ -23,7 +23,7 @@
               = link_to 'Backlog', dashboard_backlog_path, action: 'backlog'
 
             li.dropdown class=('active' if @page_title == 'Minister report - MOJ Parliamentary Questions' || @page_title == 'Press desk report - MOJ Parliamentary Questions')
-              a.dropdown-toggle data-toggle="dropdown" data-target="#-"
+              a.dropdown-toggle data-toggle="dropdown" data-target="#-" href="#"
                 | Reports
                 span.caret
               ul.dropdown-menu role="menu"


### PR DESCRIPTION
## Description
Make it possible to tab onto Reports tab

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
n/a

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3812

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
tab through navigation, you should be able to tab onto reports tab
