### PR TITLE
CT-3796 Fix sign in tab title

### DIFF
--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,3 +1,5 @@
+- content_for :page_title do
+  = 'Sign in - ' 
 = render partial: "shared/flash_messages", flash: flash
 h1.heading-large Sign in
 = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|


### PR DESCRIPTION
## Description
Change first part of tab title to "Sign in" instead of ""

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/22935203/139090038-b8183f3c-d338-41df-87ba-6af15ce1af07.png)


After: 
![image](https://user-images.githubusercontent.com/22935203/139089858-7e20c6bb-5b7f-47a3-8783-f77fef54f306.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3796

### Deployment
n/a

### Manual testing instructions
Check first part of tab title on "Sign in" page, should say "Sign in"
