### PR TITLE
CT-3799 Move sign in error to below H1

### DIFF
--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,9 +1,10 @@
 - content_for :page_title do
   = 'Sign in - ' 
-= render partial: "shared/flash_messages", flash: flash
+
 h1.heading-large Sign in
 = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
   fieldset
+    = render partial: "shared/flash_messages", flash: flash
     = devise_error_messages!
     .form-group
       label.form-label for="user_email"  Email


### PR DESCRIPTION
## Description
Move validation error on sign in page under H1 title

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
old: 
![image](https://user-images.githubusercontent.com/22935203/139109042-7f45ff84-373d-4eaf-b711-ae1dc9ddfae8.png)


new:
![image](https://user-images.githubusercontent.com/22935203/139108916-962f44ad-0924-43aa-8329-1ab2b4c514d1.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3799

### Deployment
n/a
### Manual testing instructions
Go to sign in page and try to sign in with blank details. Should show error under Sign in title.
