### PR TITLE
CT-3867 Fix status filter label and wording

### DIFF
--- a/app/views/reports/filter_all.html.slim
+++ b/app/views/reports/filter_all.html.slim
@@ -22,8 +22,8 @@ div#filter-report
             label.form-label for="press_desk_id"  Press Desk
             = select_tag 'press_desk_id', content_tag(:option,'Select a press desk',:value=>'') + options_from_collection_for_select(@press_desks, 'id', 'name', params[:press_desk_id] )
           .form-group
-            label.form-label for="progress_id"  Status
-            = select_tag 'state', content_tag(:option,'Select a progress', :value=>'') + options_for_select(@states, params[:state] )
+            label.form-label for="state"  Status
+            = select_tag 'state', content_tag(:option,'Select status', :value=>'') + options_for_select(@states, params[:state] )
           .form-group
             = submit_tag 'Report' , class: 'button' , :onclick=> "ga('send', 'event', 'reports', 'view', 'pq filter')"
             = link_to 'Reset', filter_all_path, class: 'button-secondary'


### PR DESCRIPTION
## Description
Fix filter status label and change wording to make more sense

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots

before:
![image](https://user-images.githubusercontent.com/22935203/140332997-4121be9f-40cb-4bc5-927d-d115f90440c9.png)

after: 
![image](https://user-images.githubusercontent.com/22935203/140332919-0e653308-bd0c-43ba-8e2f-c15a8d27e4c2.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3867

### Deployment
n/a

### Manual testing instructions
Go to reports > (any report) > click on the name or the numbers in the report > click on "Status" - should take you into the dropdown. Also dropdown wording should say "Select status"
