### PR TITLE
CT-3847 Add bg colour to active tab

### DIFF
--- a/app/assets/stylesheets/vendor/bootstrap.scss
+++ b/app/assets/stylesheets/vendor/bootstrap.scss
@@ -3927,6 +3927,12 @@ textarea.input-group-sm > .input-group-btn > .btn {
 
 .nav-stacked > li {
   float: none;
+
+  &.active {
+    a:active, a:hover, a:focus {
+      background-color: #efefef;
+    }
+  }
 }
 
 .nav-stacked > li + li {


### PR DESCRIPTION
## Description
Add background colour to active tab. Using Bootstrap file because it's already been changed a lot - so vendor rules don't really apply.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
Before on hover
![image](https://user-images.githubusercontent.com/22935203/142007626-e8a151a1-4162-42c2-a15d-1d7d319261f3.png)
After on hover
![image](https://user-images.githubusercontent.com/22935203/142007828-3cfeb96a-d37f-4ef1-b171-b617e02c3f7e.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3847

### Deployment
n/a

### Manual testing instructions
Go to PQ detail page and tab through the tabs. When you tab through the active one it should go grey.
