### PR TITLE
CT-3830 Move commission button to bottom of form

### DIFF
--- a/app/views/dashboard/_question_data_uncommissioned.html.slim
+++ b/app/views/dashboard/_question_data_uncommissioned.html.slim
@@ -14,9 +14,6 @@
           = render partial: 'shared/action_officer_selection', locals: {action_officers: action_officers, question: question, form: f, reassign: false}
           .form-group
             = f.hidden_field(:pq_id , :value => question.id)
-            br/
-            = f.submit 'Commission', :class => 'button commission-button'
-    /!, :disabled => disabled, data: {disable_with: 'Commissioning...'} .commissioning-error-message
 
     /! start of sub column 2
     .col-md-5
@@ -37,3 +34,6 @@
           input.deadline-date.form-control.required-for-commission id="pq_internal_deadline-#{question.id}" name="commission_form[internal_deadline]" type="text" value=(question.internal_deadline.to_s)
           span.fa.fa-calendar title="select a date"
         = render partial: 'shared/deadline_time', locals: {internal_deadline: question.internal_deadline, is_closed: question.closed?, draft_reply: question.draft_answer_received}
+    .form-group  
+      = f.submit 'Commission', :class => 'button commission-button'
+    /!, :disabled => disabled, data: {disable_with: 'Commissioning...'} .commissioning-error-message


### PR DESCRIPTION
## Description
Move commission button to end of form so when you zoom in or mobile view it's no in the middle of the form.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
before:
![image](https://user-images.githubusercontent.com/22935203/142208877-919b2058-a83e-430d-a161-d88132f00ea8.png)

after:
![image](https://user-images.githubusercontent.com/22935203/142221937-7a211a09-6808-4b0c-9025-82e6c41438dc.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3830

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->


