### PR TITLE
CT-3834 Fix label contrast in sidebar

### DIFF
--- a/app/assets/stylesheets/pq.scss
+++ b/app/assets/stylesheets/pq.scss
@@ -657,7 +657,7 @@ textarea.form-control {
 
   // make un-commissioned questions form labels look like
   // h3s used for commissioned questions
-  label.form-label { color: $secondary-text-colour; }
+  label.form-label { color: $text-colour; }
 
 }
 

--- a/app/assets/stylesheets/pq.scss
+++ b/app/assets/stylesheets/pq.scss
@@ -652,13 +652,9 @@ textarea.form-control {
     margin: 0 0 6px 0;
   }
 
-  //formatting of the action officers listed in the PQ's on the dashboard when commissioning
   .select2-search-choice div { line-height: 1em; }
 
-  // make un-commissioned questions form labels look like
-  // h3s used for commissioned questions
-  label.form-label { color: $text-colour; }
-
+  label.form-label { color: $secondary-text-colour; }
 }
 
 /* = PQ Details Page (/pqs/[uin]) ============================================ */


### PR DESCRIPTION
## Description
Fix contrast of label under `Edit PQ Dates`

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
before:
![image](https://user-images.githubusercontent.com/22935203/145840595-b74eadc4-466c-4079-ab0e-738e60f5a5f6.png)


after:
![image](https://user-images.githubusercontent.com/22935203/145840502-8fc6d34d-7ac8-4b09-b388-f91454b6fc69.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3834

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Go to In Progress page then click on `PQ dates` in sidebar
