### PR TITLE
CT-3811 Fix unlock page style and forgot password title

### DIFF
--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -1,4 +1,4 @@
-h1 Forgot your password?
+h1.heading-large Forgot your password?
 = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
   = devise_error_messages!
   fieldset

--- a/app/views/devise/unlocks/new.html.slim
+++ b/app/views/devise/unlocks/new.html.slim
@@ -1,9 +1,9 @@
-h1 Resend unlock instructions
+h1.heading-large Resend unlock instructions
 = form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
   = devise_error_messages!
-  div
-    = f.label :email
-    br/
-    = f.email_field :email, autofocus: true
-  div= f.submit "Resend unlock instructions"
+  .form-group
+    label.form-label for="user_email"  Email
+    = f.email_field :email, class: 'form-control', autofocus: true
+  .form-group
+    = f.submit "Resend unlock instructions", :class => 'button'
 = render "devise/shared/links"


### PR DESCRIPTION
## Description
Fix unlock page styling by making HTML consistent and fix title class for forgot password

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
before:
![image](https://user-images.githubusercontent.com/22935203/154065527-9afbb44a-d5f7-411c-ab50-99ebcfecd47b.png)



after:
![image](https://user-images.githubusercontent.com/22935203/154065045-34ff35b1-1b29-4334-81af-e70b0032c9c5.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3811

### Deployment
n/a

### Manual testing instructions
Click on "Didn't receive unlock instructions?" On sign in page.
