### PR TITLE
CT-4028 Add unhandled error pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,7 +51,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def set_page_title
-    @page_title = 'MOJ Parliamentary Questions'
+    @page_title = 'Parliamentary Questions - Ministry of Justice'
   end
 
   def request_url
@@ -67,7 +67,7 @@ class ApplicationController < ActionController::Base
   def show_error_page_and_increment_statsd(err_number, exception = nil)
     $statsd.increment("#{StatsHelper::PAGES_ERRORS}.#{err_number}")
     respond_to do |format|
-      format.html { render file: "public/#{err_number}.html", status: err_number }
+      format.html { render file: "public/#{err_number}.html", status: err_number, layout: nil }
       format.all  { head :no_content, status: err_number }
     end
     backtrace = exception.nil? ? nil : exception.backtrace

--- a/public/400.html
+++ b/public/400.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <title>Error - 404 - Page cannot be found - Parliamentary Questions -  Ministry of Justice</title>
+        <title>Error - 400 - Bad request - Parliamentary Questions -  Ministry of Justice</title>
 
         <link rel="stylesheet" media="all" href="/assets/application.css" />
         <link href="/assets/govuk-template.css" media="screen" rel="stylesheet" />
@@ -22,7 +22,7 @@
         </div>
 
         <header role="banner" id="global-header" class="with-proposition">
-                        <div class="header-wrapper">
+            <div class="header-wrapper">
                 <div class="header-global">
                     <div class="header-logo">
                         <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
@@ -44,11 +44,9 @@
                 <div id="wrapper" class="group live">
                     <section id="content" role="main">
                         <header class="page-header group">
-                            <h1 class="heading-xlarge">This page cannot be found</h1>
+                            <h1 class="heading-xlarge">Sorry, there is a problem with the service</h1>
                         </header>
-                        <p>If you typed the web address, check it is correct.</p>
-                        <p>If you pasted the web address, check you copied the entire address.</p>
-                        <p>If the web address is correct or you selected a link or button, please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=404 error report">pqsupport@digital.justice.gov.uk</a> with the details to report this issue.</p>
+                        <p>Please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=400 error report">pqsupport@digital.justice.gov.uk</a> with the details on how you got here to report this issue.</p>
                     </section>
                 </div>
 
@@ -74,6 +72,7 @@
         </footer>
 
         <div id="global-app-error" class="app-error hidden"></div>
+
         <script>
             (function (i, s, o, g, r, a, m) {
               i['GoogleAnalyticsObject'] = r;
@@ -87,7 +86,6 @@
             })
             (window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
             ga('create', 'UA-37377084-14', 'auto');
-            ga('send', 'pageview');
-        </script>
+            ga('send', 'pageview');</script>
     </body>
 </html>

--- a/public/401.html
+++ b/public/401.html
@@ -1,61 +1,91 @@
 <!DOCTYPE html>
-<html>
-<head>
-  <title>Unauthorized (401)</title>
-  <style>
-  body {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-  }
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>Error - 401 - Unauthorised - Parliamentary Questions -  Ministry of Justice</title>
 
-  div.dialog {
-    width: 25em;
-    margin: 4em auto 0 auto;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 4em 0 4em;
-  }
+        <link rel="stylesheet" media="all" href="/assets/application.css" />
+        <link href="/assets/govuk-template.css" media="screen" rel="stylesheet" />
+        <link href="/assets/govuk-template-print.css" media="print" rel="stylesheet" />
+        <link href="/assets/fonts.css" media="all" rel="stylesheet" />
 
-  h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta property="og:image" content="/assets/opengraph-image.png">
+    </head>
 
-  body > p {
-    width: 33em;
-    margin: 0 auto 1em;
-    padding: 1em 0;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow:0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
-</head>
+    <body class="controller-sessions">
 
-<body>
-  <!-- This file lives in public/404.html -->
-  <div class="dialog">
-    <h1>Unauthorized.</h1>
-    <p>You don't have permission to see the page. (Error 401)</p>
-    <p>There has been a technical problem. Please try again.</p>
-    <p>If the problem continues please contact technical support on <a href="mailto:pqsupport@digital.justice.gov.uk">pqsupport@digital.justice.gov.uk</a></p>
-  </div>
-  <p></p>
-</body>
+        <div id="skiplink-container">
+            <div>
+                <a href="#content" class="skiplink">Skip to main content</a>
+            </div>
+        </div>
+
+        <header role="banner" id="global-header" class="with-proposition">
+                        <div class="header-wrapper">
+                <div class="header-global">
+                    <div class="header-logo">
+                        <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
+                          <img src="/assets/gov.uk_logotype_crown_invert_trans-203e1db49d3eff430d7dc450ce723c1002542fe1d2bce661b6d8571f14c1043c.png" width="36" height="32" alt=""> GOV.UK
+                        </a>
+                    </div>          
+                </div>
+                <div class="header-proposition">
+                    <div class="content"><a href="/" id="proposition-name">PQ Tracker</a>
+                    </div>
+                </div>
+            </div>
+        </header>
+
+        <div id="global-header-bar"></div>
+
+        <div class="grid-row"><div class="column-full">
+            <main id='page-container' role='main'>
+                <div id="wrapper" class="group live">
+                    <section id="content" role="main">
+                        <header class="page-header group">
+                            <h1 class="heading-xlarge">Sorry, you are not authorised to view this page</h1>
+                        </header>
+                        <p>Please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=401 error report">pqsupport@digital.justice.gov.uk</a> with the details on how you got here to report this issue.</p>
+                    </section>
+                </div>
+
+            </main>
+
+        </div></div>
+
+        <footer class="group js-footer" id="footer" role="contentinfo">
+            <div class="footer-wrapper">
+                <div class="footer-meta">
+                    <div class="footer-meta-inner">
+                        <div class="open-government-licence">
+                            <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
+                            <p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
+                        </div>
+                    </div>
+
+                    <div class="copyright">
+                        <a href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
+                    </div>
+                </div>
+            </div>
+        </footer>
+
+        <div id="global-app-error" class="app-error hidden"></div>
+
+        <script>
+            (function (i, s, o, g, r, a, m) {
+              i['GoogleAnalyticsObject'] = r;
+              i[r] = i[r] || function () {
+                        (i[r].q = i[r].q || []).push(arguments)
+                      }, i[r].l = 1 * new Date();
+              a = s.createElement(o), m = s.getElementsByTagName(o)[0];
+              a.async = 1;
+              a.src = g;
+              m.parentNode.insertBefore(a, m)
+            })
+            (window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+            ga('create', 'UA-37377084-14', 'auto');
+            ga('send', 'pageview');</script>
+    </body>
 </html>
-

--- a/public/403.html
+++ b/public/403.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <title>Error - 404 - Page cannot be found - Parliamentary Questions -  Ministry of Justice</title>
+        <title>Error - 403 - Forbidden - Parliamentary Questions -  Ministry of Justice</title>
 
         <link rel="stylesheet" media="all" href="/assets/application.css" />
         <link href="/assets/govuk-template.css" media="screen" rel="stylesheet" />
@@ -44,11 +44,9 @@
                 <div id="wrapper" class="group live">
                     <section id="content" role="main">
                         <header class="page-header group">
-                            <h1 class="heading-xlarge">This page cannot be found</h1>
+                            <h1 class="heading-xlarge">Sorry, you are not authorised to view this page</h1>
                         </header>
-                        <p>If you typed the web address, check it is correct.</p>
-                        <p>If you pasted the web address, check you copied the entire address.</p>
-                        <p>If the web address is correct or you selected a link or button, please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=404 error report">pqsupport@digital.justice.gov.uk</a> with the details to report this issue.</p>
+                        <p>Please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=403 error report">pqsupport@digital.justice.gov.uk</a> with the details on how you got here to report this issue.</p>
                     </section>
                 </div>
 
@@ -74,6 +72,7 @@
         </footer>
 
         <div id="global-app-error" class="app-error hidden"></div>
+
         <script>
             (function (i, s, o, g, r, a, m) {
               i['GoogleAnalyticsObject'] = r;
@@ -87,7 +86,6 @@
             })
             (window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
             ga('create', 'UA-37377084-14', 'auto');
-            ga('send', 'pageview');
-        </script>
+            ga('send', 'pageview');</script>
     </body>
 </html>

--- a/public/405.html
+++ b/public/405.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <title>Error - 404 - Page cannot be found - Parliamentary Questions -  Ministry of Justice</title>
+        <title>Error - 405 - Method not allowed - Parliamentary Questions -  Ministry of Justice</title>
 
         <link rel="stylesheet" media="all" href="/assets/application.css" />
         <link href="/assets/govuk-template.css" media="screen" rel="stylesheet" />
@@ -44,11 +44,9 @@
                 <div id="wrapper" class="group live">
                     <section id="content" role="main">
                         <header class="page-header group">
-                            <h1 class="heading-xlarge">This page cannot be found</h1>
+                            <h1 class="heading-xlarge">Sorry, you are not authorised to view this page</h1>
                         </header>
-                        <p>If you typed the web address, check it is correct.</p>
-                        <p>If you pasted the web address, check you copied the entire address.</p>
-                        <p>If the web address is correct or you selected a link or button, please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=404 error report">pqsupport@digital.justice.gov.uk</a> with the details to report this issue.</p>
+                        <p>Please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=405 error report">pqsupport@digital.justice.gov.uk</a> with the details on how you got here to report this issue.</p>
                     </section>
                 </div>
 
@@ -74,6 +72,7 @@
         </footer>
 
         <div id="global-app-error" class="app-error hidden"></div>
+
         <script>
             (function (i, s, o, g, r, a, m) {
               i['GoogleAnalyticsObject'] = r;
@@ -87,7 +86,6 @@
             })
             (window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
             ga('create', 'UA-37377084-14', 'auto');
-            ga('send', 'pageview');
-        </script>
+            ga('send', 'pageview');</script>
     </body>
 </html>

--- a/public/406.html
+++ b/public/406.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <title>Error - 404 - Page cannot be found - Parliamentary Questions -  Ministry of Justice</title>
+        <title>Error - 406 - Not acceptable - Parliamentary Questions -  Ministry of Justice</title>
 
         <link rel="stylesheet" media="all" href="/assets/application.css" />
         <link href="/assets/govuk-template.css" media="screen" rel="stylesheet" />
@@ -44,11 +44,9 @@
                 <div id="wrapper" class="group live">
                     <section id="content" role="main">
                         <header class="page-header group">
-                            <h1 class="heading-xlarge">This page cannot be found</h1>
+                            <h1 class="heading-xlarge">Sorry, you are not authorised to view this page</h1>
                         </header>
-                        <p>If you typed the web address, check it is correct.</p>
-                        <p>If you pasted the web address, check you copied the entire address.</p>
-                        <p>If the web address is correct or you selected a link or button, please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=404 error report">pqsupport@digital.justice.gov.uk</a> with the details to report this issue.</p>
+                        <p>Please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=406 error report">pqsupport@digital.justice.gov.uk</a> with the details on how you got here to report this issue.</p>
                     </section>
                 </div>
 
@@ -74,6 +72,7 @@
         </footer>
 
         <div id="global-app-error" class="app-error hidden"></div>
+
         <script>
             (function (i, s, o, g, r, a, m) {
               i['GoogleAnalyticsObject'] = r;
@@ -87,7 +86,6 @@
             })
             (window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
             ga('create', 'UA-37377084-14', 'auto');
-            ga('send', 'pageview');
-        </script>
+            ga('send', 'pageview');</script>
     </body>
 </html>

--- a/public/408.html
+++ b/public/408.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <title>Error - 404 - Page cannot be found - Parliamentary Questions -  Ministry of Justice</title>
+        <title>Error - 408 - Request timeout - Parliamentary Questions -  Ministry of Justice</title>
 
         <link rel="stylesheet" media="all" href="/assets/application.css" />
         <link href="/assets/govuk-template.css" media="screen" rel="stylesheet" />
@@ -44,11 +44,9 @@
                 <div id="wrapper" class="group live">
                     <section id="content" role="main">
                         <header class="page-header group">
-                            <h1 class="heading-xlarge">This page cannot be found</h1>
+                            <h1 class="heading-xlarge">Sorry, your request was timed out</h1>
                         </header>
-                        <p>If you typed the web address, check it is correct.</p>
-                        <p>If you pasted the web address, check you copied the entire address.</p>
-                        <p>If the web address is correct or you selected a link or button, please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=404 error report">pqsupport@digital.justice.gov.uk</a> with the details to report this issue.</p>
+                        <p>Please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=408 error report">pqsupport@digital.justice.gov.uk</a> with the details on how you got here to report this issue.</p>
                     </section>
                 </div>
 
@@ -74,6 +72,7 @@
         </footer>
 
         <div id="global-app-error" class="app-error hidden"></div>
+
         <script>
             (function (i, s, o, g, r, a, m) {
               i['GoogleAnalyticsObject'] = r;
@@ -87,7 +86,6 @@
             })
             (window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
             ga('create', 'UA-37377084-14', 'auto');
-            ga('send', 'pageview');
-        </script>
+            ga('send', 'pageview');</script>
     </body>
 </html>

--- a/public/411.html
+++ b/public/411.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <title>Error - 404 - Page cannot be found - Parliamentary Questions -  Ministry of Justice</title>
+        <title>Error - 411 - Length required - Parliamentary Questions -  Ministry of Justice</title>
 
         <link rel="stylesheet" media="all" href="/assets/application.css" />
         <link href="/assets/govuk-template.css" media="screen" rel="stylesheet" />
@@ -44,11 +44,9 @@
                 <div id="wrapper" class="group live">
                     <section id="content" role="main">
                         <header class="page-header group">
-                            <h1 class="heading-xlarge">This page cannot be found</h1>
+                            <h1 class="heading-xlarge">Sorry, there is a problem with this service</h1>
                         </header>
-                        <p>If you typed the web address, check it is correct.</p>
-                        <p>If you pasted the web address, check you copied the entire address.</p>
-                        <p>If the web address is correct or you selected a link or button, please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=404 error report">pqsupport@digital.justice.gov.uk</a> with the details to report this issue.</p>
+                        <p>Please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=411 error report">pqsupport@digital.justice.gov.uk</a> with the details on how you got here to report this issue.</p>
                     </section>
                 </div>
 
@@ -74,6 +72,7 @@
         </footer>
 
         <div id="global-app-error" class="app-error hidden"></div>
+
         <script>
             (function (i, s, o, g, r, a, m) {
               i['GoogleAnalyticsObject'] = r;
@@ -87,7 +86,6 @@
             })
             (window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
             ga('create', 'UA-37377084-14', 'auto');
-            ga('send', 'pageview');
-        </script>
+            ga('send', 'pageview');</script>
     </body>
 </html>

--- a/public/413.html
+++ b/public/413.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <title>Error - 404 - Page cannot be found - Parliamentary Questions -  Ministry of Justice</title>
+        <title>Error - 413 - Request entity too large - Parliamentary Questions -  Ministry of Justice</title>
 
         <link rel="stylesheet" media="all" href="/assets/application.css" />
         <link href="/assets/govuk-template.css" media="screen" rel="stylesheet" />
@@ -44,11 +44,9 @@
                 <div id="wrapper" class="group live">
                     <section id="content" role="main">
                         <header class="page-header group">
-                            <h1 class="heading-xlarge">This page cannot be found</h1>
+                            <h1 class="heading-xlarge">Request entity too large</h1>
                         </header>
-                        <p>If you typed the web address, check it is correct.</p>
-                        <p>If you pasted the web address, check you copied the entire address.</p>
-                        <p>If the web address is correct or you selected a link or button, please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=404 error report">pqsupport@digital.justice.gov.uk</a> with the details to report this issue.</p>
+                        <p>Please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=413 error report">pqsupport@digital.justice.gov.uk</a> with the details on how you got here to report this issue.</p>
                     </section>
                 </div>
 
@@ -74,6 +72,7 @@
         </footer>
 
         <div id="global-app-error" class="app-error hidden"></div>
+
         <script>
             (function (i, s, o, g, r, a, m) {
               i['GoogleAnalyticsObject'] = r;
@@ -87,7 +86,6 @@
             })
             (window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
             ga('create', 'UA-37377084-14', 'auto');
-            ga('send', 'pageview');
-        </script>
+            ga('send', 'pageview');</script>
     </body>
 </html>

--- a/public/415.html
+++ b/public/415.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <title>Error - 404 - Page cannot be found - Parliamentary Questions -  Ministry of Justice</title>
+        <title>Error - 415 - Unsupported media type - Parliamentary Questions -  Ministry of Justice</title>
 
         <link rel="stylesheet" media="all" href="/assets/application.css" />
         <link href="/assets/govuk-template.css" media="screen" rel="stylesheet" />
@@ -44,11 +44,9 @@
                 <div id="wrapper" class="group live">
                     <section id="content" role="main">
                         <header class="page-header group">
-                            <h1 class="heading-xlarge">This page cannot be found</h1>
+                            <h1 class="heading-xlarge">Unsupported media type</h1>
                         </header>
-                        <p>If you typed the web address, check it is correct.</p>
-                        <p>If you pasted the web address, check you copied the entire address.</p>
-                        <p>If the web address is correct or you selected a link or button, please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=404 error report">pqsupport@digital.justice.gov.uk</a> with the details to report this issue.</p>
+                        <p>Please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=415 error report">pqsupport@digital.justice.gov.uk</a> with the details on how you got here to report this issue.</p>
                     </section>
                 </div>
 
@@ -74,6 +72,7 @@
         </footer>
 
         <div id="global-app-error" class="app-error hidden"></div>
+
         <script>
             (function (i, s, o, g, r, a, m) {
               i['GoogleAnalyticsObject'] = r;
@@ -87,7 +86,6 @@
             })
             (window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
             ga('create', 'UA-37377084-14', 'auto');
-            ga('send', 'pageview');
-        </script>
+            ga('send', 'pageview');</script>
     </body>
 </html>

--- a/public/416.html
+++ b/public/416.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <title>Error - 404 - Page cannot be found - Parliamentary Questions -  Ministry of Justice</title>
+        <title>Error - 416 - Requested range not satisfiable - Parliamentary Questions -  Ministry of Justice</title>
 
         <link rel="stylesheet" media="all" href="/assets/application.css" />
         <link href="/assets/govuk-template.css" media="screen" rel="stylesheet" />
@@ -44,11 +44,9 @@
                 <div id="wrapper" class="group live">
                     <section id="content" role="main">
                         <header class="page-header group">
-                            <h1 class="heading-xlarge">This page cannot be found</h1>
+                            <h1 class="heading-xlarge">Sorry, there is a problem with this service</h1>
                         </header>
-                        <p>If you typed the web address, check it is correct.</p>
-                        <p>If you pasted the web address, check you copied the entire address.</p>
-                        <p>If the web address is correct or you selected a link or button, please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=404 error report">pqsupport@digital.justice.gov.uk</a> with the details to report this issue.</p>
+                        <p>Please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=416 error report">pqsupport@digital.justice.gov.uk</a> with the details on how you got here to report this issue.</p>
                     </section>
                 </div>
 
@@ -74,6 +72,7 @@
         </footer>
 
         <div id="global-app-error" class="app-error hidden"></div>
+
         <script>
             (function (i, s, o, g, r, a, m) {
               i['GoogleAnalyticsObject'] = r;
@@ -87,7 +86,6 @@
             })
             (window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
             ga('create', 'UA-37377084-14', 'auto');
-            ga('send', 'pageview');
-        </script>
+            ga('send', 'pageview');</script>
     </body>
 </html>

--- a/public/422.html
+++ b/public/422.html
@@ -1,61 +1,91 @@
 <!DOCTYPE html>
-<html>
-<head>
-  <title>The change you wanted was rejected (422)</title>
-  <style>
-  body {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-  }
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>Error - 422 - Unprocessable entity - Parliamentary Questions -  Ministry of Justice</title>
 
-  div.dialog {
-    width: 25em;
-    margin: 4em auto 0 auto;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 4em 0 4em;
-  }
+        <link rel="stylesheet" media="all" href="/assets/application.css" />
+        <link href="/assets/govuk-template.css" media="screen" rel="stylesheet" />
+        <link href="/assets/govuk-template-print.css" media="print" rel="stylesheet" />
+        <link href="/assets/fonts.css" media="all" rel="stylesheet" />
 
-  h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta property="og:image" content="/assets/opengraph-image.png">
+    </head>
 
-  body > p {
-    width: 33em;
-    margin: 0 auto 1em;
-    padding: 1em 0;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow:0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
-</head>
+    <body class="controller-sessions">
 
-<body>
-  <!-- This file lives in public/422.html -->
-  <div class="dialog">
-    <h1>The change you wanted was rejected.</h1>
-    <p>Maybe you tried to change something you didn't have access to.</p>
-      <p>If the problem continues please contact technical support on <a href="mailto:pqsupport@digital.justice.gov.uk">pqsupport@digital.justice.gov.uk</a></p>
+        <div id="skiplink-container">
+            <div>
+                <a href="#content" class="skiplink">Skip to main content</a>
+            </div>
+        </div>
 
-  </div>
-  <p>If you are the application owner check the logs for more information.</p>
-</body>
+        <header role="banner" id="global-header" class="with-proposition">
+                        <div class="header-wrapper">
+                <div class="header-global">
+                    <div class="header-logo">
+                        <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
+                          <img src="/assets/gov.uk_logotype_crown_invert_trans-203e1db49d3eff430d7dc450ce723c1002542fe1d2bce661b6d8571f14c1043c.png" width="36" height="32" alt=""> GOV.UK
+                        </a>
+                    </div>          
+                </div>
+                <div class="header-proposition">
+                    <div class="content"><a href="/" id="proposition-name">PQ Tracker</a>
+                    </div>
+                </div>
+            </div>
+        </header>
+
+        <div id="global-header-bar"></div>
+
+        <div class="grid-row"><div class="column-full">
+            <main id='page-container' role='main'>
+                <div id="wrapper" class="group live">
+                    <section id="content" role="main">
+                        <header class="page-header group">
+                            <h1 class="heading-xlarge">Sorry, there is a problem with this service</h1>
+                        </header>
+                        <p>Please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=422 error report">pqsupport@digital.justice.gov.uk</a> with the details on how you got here to report this issue.</p>
+                    </section>
+                </div>
+
+            </main>
+
+        </div></div>
+
+        <footer class="group js-footer" id="footer" role="contentinfo">
+            <div class="footer-wrapper">
+                <div class="footer-meta">
+                    <div class="footer-meta-inner">
+                        <div class="open-government-licence">
+                            <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
+                            <p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
+                        </div>
+                    </div>
+
+                    <div class="copyright">
+                        <a href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
+                    </div>
+                </div>
+            </div>
+        </footer>
+
+        <div id="global-app-error" class="app-error hidden"></div>
+
+        <script>
+            (function (i, s, o, g, r, a, m) {
+              i['GoogleAnalyticsObject'] = r;
+              i[r] = i[r] || function () {
+                        (i[r].q = i[r].q || []).push(arguments)
+                      }, i[r].l = 1 * new Date();
+              a = s.createElement(o), m = s.getElementsByTagName(o)[0];
+              a.async = 1;
+              a.src = g;
+              m.parentNode.insertBefore(a, m)
+            })
+            (window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+            ga('create', 'UA-37377084-14', 'auto');
+            ga('send', 'pageview');</script>
+    </body>
 </html>
-

--- a/public/423.html
+++ b/public/423.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <title>Error - 404 - Page cannot be found - Parliamentary Questions -  Ministry of Justice</title>
+        <title>Error - 423 - Locked - Parliamentary Questions -  Ministry of Justice</title>
 
         <link rel="stylesheet" media="all" href="/assets/application.css" />
         <link href="/assets/govuk-template.css" media="screen" rel="stylesheet" />
@@ -44,11 +44,9 @@
                 <div id="wrapper" class="group live">
                     <section id="content" role="main">
                         <header class="page-header group">
-                            <h1 class="heading-xlarge">This page cannot be found</h1>
+                            <h1 class="heading-xlarge">Sorry, there is a problem with this service</h1>
                         </header>
-                        <p>If you typed the web address, check it is correct.</p>
-                        <p>If you pasted the web address, check you copied the entire address.</p>
-                        <p>If the web address is correct or you selected a link or button, please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=404 error report">pqsupport@digital.justice.gov.uk</a> with the details to report this issue.</p>
+                        <p>Please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=423 error report">pqsupport@digital.justice.gov.uk</a> with the details on how you got here to report this issue.</p>
                     </section>
                 </div>
 
@@ -74,6 +72,7 @@
         </footer>
 
         <div id="global-app-error" class="app-error hidden"></div>
+
         <script>
             (function (i, s, o, g, r, a, m) {
               i['GoogleAnalyticsObject'] = r;
@@ -87,7 +86,6 @@
             })
             (window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
             ga('create', 'UA-37377084-14', 'auto');
-            ga('send', 'pageview');
-        </script>
+            ga('send', 'pageview');</script>
     </body>
 </html>

--- a/public/424.html
+++ b/public/424.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <title>Error - 404 - Page cannot be found - Parliamentary Questions -  Ministry of Justice</title>
+        <title>Error - 403 - Failed dependency - Parliamentary Questions -  Ministry of Justice</title>
 
         <link rel="stylesheet" media="all" href="/assets/application.css" />
         <link href="/assets/govuk-template.css" media="screen" rel="stylesheet" />
@@ -44,11 +44,9 @@
                 <div id="wrapper" class="group live">
                     <section id="content" role="main">
                         <header class="page-header group">
-                            <h1 class="heading-xlarge">This page cannot be found</h1>
+                            <h1 class="heading-xlarge">Sorry, there is a problem with this service</h1>
                         </header>
-                        <p>If you typed the web address, check it is correct.</p>
-                        <p>If you pasted the web address, check you copied the entire address.</p>
-                        <p>If the web address is correct or you selected a link or button, please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=404 error report">pqsupport@digital.justice.gov.uk</a> with the details to report this issue.</p>
+                        <p>Please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=424 error report">pqsupport@digital.justice.gov.uk</a> with the details on how you got here to report this issue.</p>
                     </section>
                 </div>
 
@@ -74,6 +72,7 @@
         </footer>
 
         <div id="global-app-error" class="app-error hidden"></div>
+
         <script>
             (function (i, s, o, g, r, a, m) {
               i['GoogleAnalyticsObject'] = r;
@@ -87,7 +86,6 @@
             })
             (window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
             ga('create', 'UA-37377084-14', 'auto');
-            ga('send', 'pageview');
-        </script>
+            ga('send', 'pageview');</script>
     </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -1,59 +1,91 @@
 <!DOCTYPE html>
-<html>
-<head>
-  <title>We're sorry, but something went wrong (500)</title>
-  <style>
-  body {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-  }
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>Error - 500 - Internal server error - Parliamentary Questions -  Ministry of Justice</title>
 
-  div.dialog {
-    width: 25em;
-    margin: 4em auto 0 auto;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 4em 0 4em;
-  }
+        <link rel="stylesheet" media="all" href="/assets/application.css" />
+        <link href="/assets/govuk-template.css" media="screen" rel="stylesheet" /><!--<![endif]-->
+        <link href="/assets/govuk-template-print.css" media="print" rel="stylesheet" />
+        <link href="/assets/fonts.css" media="all" rel="stylesheet" />
 
-  h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta property="og:image" content="/assets/opengraph-image.png">
+    </head>
 
-  body > p {
-    width: 33em;
-    margin: 0 auto 1em;
-    padding: 1em 0;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow:0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
-</head>
+    <body class="controller-sessions">
 
-<body>
-  <!-- This file lives in public/500.html -->
-  <div class="dialog">
-    <h1>We're sorry, but something went wrong. (Error 500)</h1>
-      <p>If the problem continues please contact technical support on <a href="mailto:pqsupport@digital.justice.gov.uk">pqsupport@digital.justice.gov.uk</a></p>
-  </div>
-  <p>If you are the application owner check the logs for more information.</p>
-</body>
+        <div id="skiplink-container">
+            <div>
+                <a href="#content" class="skiplink">Skip to main content</a>
+            </div>
+        </div>
+
+        <header role="banner" id="global-header" class="with-proposition">
+                        <div class="header-wrapper">
+                <div class="header-global">
+                    <div class="header-logo">
+                        <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
+                          <img src="/assets/gov.uk_logotype_crown_invert_trans-203e1db49d3eff430d7dc450ce723c1002542fe1d2bce661b6d8571f14c1043c.png" width="36" height="32" alt=""> GOV.UK
+                        </a>
+                    </div>          
+                </div>
+                <div class="header-proposition">
+                    <div class="content"><a href="/" id="proposition-name">PQ Tracker</a>
+                    </div>
+                </div>
+            </div>
+        </header>
+
+        <div id="global-header-bar"></div>
+
+        <div class="grid-row"><div class="column-full">
+            <main id='page-container' role='main'>
+                <div id="wrapper" class="group live">
+                    <section id="content" role="main">
+                        <header class="page-header group">
+                            <h1 class="heading-xlarge">Sorry, there is a problem with the service</h1>
+                        </header>
+                        <p>Please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=500 error report">pqsupport@digital.justice.gov.uk</a> with the details to report this issue.</p>
+                    </section>
+                </div>
+
+            </main>
+
+        </div></div>
+
+        <footer class="group js-footer" id="footer" role="contentinfo">
+            <div class="footer-wrapper">
+                <div class="footer-meta">
+                    <div class="footer-meta-inner">
+                        <div class="open-government-licence">
+                            <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
+                            <p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
+                        </div>
+                    </div>
+
+                    <div class="copyright">
+                        <a href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">© Crown copyright</a>
+                    </div>
+                </div>
+            </div>
+        </footer>
+
+        <div id="global-app-error" class="app-error hidden"></div>
+        <script>
+            (function (i, s, o, g, r, a, m) {
+              i['GoogleAnalyticsObject'] = r;
+              i[r] = i[r] || function () {
+                        (i[r].q = i[r].q || []).push(arguments)
+                      }, i[r].l = 1 * new Date();
+              a = s.createElement(o), m = s.getElementsByTagName(o)[0];
+              a.async = 1;
+              a.src = g;
+              m.parentNode.insertBefore(a, m)
+            })
+            (window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+            ga('create', 'UA-37377084-14', 'auto');
+            ga('send', 'pageview');
+        </script>
+    </body>
 </html>
-

--- a/public/501.html
+++ b/public/501.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <title>Error - 404 - Page cannot be found - Parliamentary Questions -  Ministry of Justice</title>
+        <title>Error - 501 - Not implemented - Parliamentary Questions -  Ministry of Justice</title>
 
         <link rel="stylesheet" media="all" href="/assets/application.css" />
         <link href="/assets/govuk-template.css" media="screen" rel="stylesheet" />
@@ -44,11 +44,9 @@
                 <div id="wrapper" class="group live">
                     <section id="content" role="main">
                         <header class="page-header group">
-                            <h1 class="heading-xlarge">This page cannot be found</h1>
+                            <h1 class="heading-xlarge">Sorry, there is a problem with this service.</h1>
                         </header>
-                        <p>If you typed the web address, check it is correct.</p>
-                        <p>If you pasted the web address, check you copied the entire address.</p>
-                        <p>If the web address is correct or you selected a link or button, please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=404 error report">pqsupport@digital.justice.gov.uk</a> with the details to report this issue.</p>
+                        <p>Please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=501 error report">pqsupport@digital.justice.gov.uk</a> with the details on how you got here to report this issue.</p>
                     </section>
                 </div>
 
@@ -74,6 +72,7 @@
         </footer>
 
         <div id="global-app-error" class="app-error hidden"></div>
+
         <script>
             (function (i, s, o, g, r, a, m) {
               i['GoogleAnalyticsObject'] = r;
@@ -87,7 +86,6 @@
             })
             (window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
             ga('create', 'UA-37377084-14', 'auto');
-            ga('send', 'pageview');
-        </script>
+            ga('send', 'pageview');</script>
     </body>
 </html>

--- a/public/504.html
+++ b/public/504.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <title>Error - 404 - Page cannot be found - Parliamentary Questions -  Ministry of Justice</title>
+        <title>Error - 504 - Gateway timeout - Parliamentary Questions -  Ministry of Justice</title>
 
         <link rel="stylesheet" media="all" href="/assets/application.css" />
         <link href="/assets/govuk-template.css" media="screen" rel="stylesheet" />
@@ -44,11 +44,9 @@
                 <div id="wrapper" class="group live">
                     <section id="content" role="main">
                         <header class="page-header group">
-                            <h1 class="heading-xlarge">This page cannot be found</h1>
+                            <h1 class="heading-xlarge">Sorry, your request has timed out</h1>
                         </header>
-                        <p>If you typed the web address, check it is correct.</p>
-                        <p>If you pasted the web address, check you copied the entire address.</p>
-                        <p>If the web address is correct or you selected a link or button, please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=404 error report">pqsupport@digital.justice.gov.uk</a> with the details to report this issue.</p>
+                        <p>Please contact <a href="mailto:pqsupport@digital.justice.gov.uk?subject=504 error report">pqsupport@digital.justice.gov.uk</a> with the details on how you got here to report this issue.</p>
                     </section>
                 </div>
 
@@ -74,6 +72,7 @@
         </footer>
 
         <div id="global-app-error" class="app-error hidden"></div>
+
         <script>
             (function (i, s, o, g, r, a, m) {
               i['GoogleAnalyticsObject'] = r;
@@ -87,7 +86,6 @@
             })
             (window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
             ga('create', 'UA-37377084-14', 'auto');
-            ga('send', 'pageview');
-        </script>
+            ga('send', 'pageview');</script>
     </body>
 </html>


### PR DESCRIPTION
## Description
add unhandled error pages for app with GA tracking so we can capture stats about when they occur. These may not all be used now but as and when they're included in the app or NGINX then errors should become more specific and display cleanly with Gov UK style, simple pages with consistency - and not required to change with app

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
e.g. 

before:
<img width="966" alt="image" src="https://user-images.githubusercontent.com/22935203/155484207-c9f5bc30-e086-44c6-abcf-1b3ac36f2227.png">


after
<img width="1105" alt="image" src="https://user-images.githubusercontent.com/22935203/155484750-ad38f4f3-046b-421d-87b0-4e2955354b7e.png">



### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-4028

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Go to invalid URL, or cause server error, or navigate manually e.g /401.html
