### PR TITLE
CT-3837 Reorganise Action officers not accepted as per ticket screenshot

### DIFF
--- a/app/assets/stylesheets/pq.scss
+++ b/app/assets/stylesheets/pq.scss
@@ -679,6 +679,7 @@ textarea.form-control {
     .date.datetimepicker, p, .text, hr, a, label {
       &.block-label { margin: 0 0 20px 0; }
       &.form-label { color: #6F777B; }
+      &.margin { margin-top: 15px; }
     }
     #save { margin-top: 40px; }
   }
@@ -755,9 +756,7 @@ textarea.form-control {
         width: 280px;
         margin-bottom: 20px;
       }
-      .ao-reminder-link {
-        margin-left: 40px; // put some space between person name and link to email them
-      }
+
       #progress-menu-fc-data .status {
         margin-bottom: .5em;
       }

--- a/app/views/pqs/_com_data.html.slim
+++ b/app/views/pqs/_com_data.html.slim
@@ -16,7 +16,7 @@ hr/
     - @pq.action_officers_pqs.order(updated_at: :desc).each do |ao_pq|
       - if ao_pq.accepted?
         - reminder_draft_count =  ao_pq.reminder_draft > 0 ? " (#{ao_pq.reminder_draft})" : ''
-        = ' '
+        br
         = link_to raw("<span class=\"fa fa-envelope-o\"></span> Draft reminder #{reminder_draft_count}"), {controller: 'action_officer_reminder', action: 'send_draft', id: ao_pq.id, remote: true}, {class: 'ao-reminder-link', title: 'Send a reminder email to do the draft'}
         p.text
           = link_to 'Manually reject this action officer', {controller: 'manual_reject_commission', action: 'reject_manual', id: ao_pq.id}, {class: 'button-secondary', title: 'Reject the question manually'}

--- a/app/views/pqs/_com_data.html.slim
+++ b/app/views/pqs/_com_data.html.slim
@@ -6,11 +6,15 @@
     span.fa.fa-calendar title="select a date"
 hr/
 .question-allocation
+  h3 Action officer(s)
+  p.text
   - if @pq.action_officers.size > 0
+    - @pq.action_officers_pqs.order(updated_at: :desc).each_with_index do |ao_pq, ind|
+      - if ind > 0
+        = ', '
+      = link_to ao_pq.action_officer.name, action_officer_path(ao_pq.action_officer)
     - @pq.action_officers_pqs.order(updated_at: :desc).each do |ao_pq|
       - if ao_pq.accepted?
-        h3 Name of Action Officer
-        = link_to ao_pq.action_officer.name, action_officer_path(ao_pq.action_officer)
         - reminder_draft_count =  ao_pq.reminder_draft > 0 ? " (#{ao_pq.reminder_draft})" : ''
         = ' '
         = link_to raw("<span class=\"fa fa-envelope-o\"></span> Draft reminder #{reminder_draft_count}"), {controller: 'action_officer_reminder', action: 'send_draft', id: ao_pq.id, remote: true}, {class: 'ao-reminder-link', title: 'Send a reminder email to do the draft'}
@@ -34,12 +38,10 @@ hr/
           = link_to po.name, press_officer_path(po)
           br/
       - if ao_pq.awaiting_response?
-        p.text
-          = link_to ao_pq.action_officer.name, action_officer_path(ao_pq.action_officer)
-          - reminder_accept_count =  ao_pq.reminder_accept > 0 ? " (#{ao_pq.reminder_accept})" : ''
-          = ' '
-          = link_to raw("<i class=\"fa fa-envelope-o\"></i> Send reminder#{reminder_accept_count}"), {controller: 'action_officer_reminder', action: 'accept_reject', id: ao_pq.id, remote: true}, {class: 'ao-reminder-link', title: 'Send an accept/reject reminder email'}
-        = link_to 'Manually reject this action officer', {controller: 'manual_reject_commission', action: 'reject_manual', id: ao_pq.id}, {class: 'button-secondary', title: 'Reject the question manually'}
+        p.text.margin
+          - reminder_accept_count =  ao_pq.reminder_accept > 0 ? " (#{ao_pq.reminder_accept} already sent)" : ''
+          = link_to raw("<i class=\"fa fa-envelope-o\"></i> Send reminder to #{ao_pq.action_officer.name} #{reminder_accept_count}"), {controller: 'action_officer_reminder', action: 'accept_reject', id: ao_pq.id, remote: true}, {class: 'ao-reminder-link', title: 'Send an accept/reject reminder email'}
+        = link_to "Manually reject #{ao_pq.action_officer.name}", {controller: 'manual_reject_commission', action: 'reject_manual', id: ao_pq.id}, {class: 'button-secondary', title: 'Reject the question manually'}
     - unless @pq.is_new?
       = render partial: 'shared/action_officer_selection', locals: {action_officers: action_officers, question: @pq, form: f, reassign: true}
 


### PR DESCRIPTION
## Description
Make non-accepted action officers section more accessible as per ticket

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/22935203/156803055-ac53a624-e66e-4b36-8cbc-ac8724b8c084.png)


after:

![image](https://user-images.githubusercontent.com/22935203/156802886-a906a917-f4e3-43c2-94b6-14f820c6cfe3.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3837

### Deployment
n/a

### Manual testing instructions
See PQ details page and click on Commission tab where action officers haven't accepted
