### PR TITLE
CT-3835 make flags pass contrast ratios

### DIFF
--- a/app/assets/stylesheets/pq.scss
+++ b/app/assets/stylesheets/pq.scss
@@ -172,21 +172,21 @@ button.close {
   margin: 0 10px 0 0;
   color: white;
   &.finance-unchecked { background-color: #b10e1e; }
-  &.no-response { background-color: #f47738; }
-  &.accepted { background-color: #28a197; }
+  &.no-response { background-color: #f47738; color: #000; }
+  &.accepted { background-color: #144D48; }
   &.answered { background-color: #006435; }
-  &.draft-pending { background-color: #85994b; }
-  &.minister-cleared { background-color: #c1a87e; }
-  &.ministerial-query { background-color: #b58840; }
-  &.pod-cleared { background-color: #a1a8ff; }
-  &.pod-query { background-color: #5461ff; }
-  &.rejected { background-color: #d0021b; }
-  &.unassigned { background-color: #bd10e0; }
-  &.with-minister { background-color: #82622e; }
+  &.draft-pending { background-color: #445729; }
+  &.minister-cleared { background-color: #c1a87e; color: #000; }
+  &.ministerial-query { background-color: #BE9046; color: #000; }
+  &.pod-cleared { background-color: #a1a8ff; color: #000; }
+  &.pod-query { background-color: #051EFF; }
+  &.rejected { background-color: #970214; }
+  &.unassigned { background-color: #890BA2; }
+  &.with-minister { background-color: #624B22; }
   &.with-pod { background-color: #2e358b; }
-  &.transferred-out { background-color: #d53880; }
-  &.transferred-in { background-color: #7d7d7d; }
-  &.will-write { background-color: #5f5f5f; }
+  &.transferred-out { background-color: #931F55; }
+  &.transferred-in { background-color: #4F4F4F; }
+  &.will-write { background-color: #C2C2C2; color: #000; }
 }
 
 //found in assignment/show and shared/_allocation_list


### PR DESCRIPTION
## Description
Fix contrast ratios of flags for accessibility - adjust colours

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
Before:
<img width="343" alt="image" src="https://user-images.githubusercontent.com/22935203/162218250-91a29dbd-f173-4270-bac5-46cc7bfa91bd.png">



After:
![image](https://user-images.githubusercontent.com/22935203/162217841-56cba805-4e52-4361-9281-17d4ab1c0412.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3835

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
View reports to see flags - Click on Google Wave to check contrast errors
