### PR TITLE
CT-3881 Fix labels and button text consistency

### DIFF
--- a/app/views/early_bird_organiser/_form.html.slim
+++ b/app/views/early_bird_organiser/_form.html.slim
@@ -5,11 +5,11 @@
     fieldset
       legend Select the dates between which you do not wish to receive the early bird email
       .form-group
-        label.form-label for="date_from" First date to turn off the early bird email 
+        label.form-label for="early_bird_organiser_date_from" First date to turn off the early bird email 
         = f.date_field :date_from, {class: 'form-control'}
       .form-group
-        label.form-label for="date_to" Last date the early bird email is off 
+        label.form-label for="early_bird_organiser_date_to" Last date the early bird email is off 
         = f.date_field :date_to , {class: 'form-control'}
       .form-group
         br
-        = f.submit 'Save and continue',:id => 'save', :class => 'button'
+        = f.submit 'Save',:id => 'save', :class => 'button'


### PR DESCRIPTION
## Description
Fix form labels on Early bird organiser and make button text consistent with others.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
No significant visual changes

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3881

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Go to Settings > Early bird organiser. Click on labels. Also button should say "Save"
