### PR TITLE
CT-3836 Update PQ details page headings to be with content

### DIFF
--- a/app/assets/stylesheets/pq.scss
+++ b/app/assets/stylesheets/pq.scss
@@ -707,6 +707,7 @@ textarea.form-control {
 
   ul.nav-tabs li a {
     outline: 0;
+    color: $text-colour;
   }
 
   // remove firefox's dotted line

--- a/app/assets/stylesheets/pq.scss
+++ b/app/assets/stylesheets/pq.scss
@@ -680,9 +680,10 @@ textarea.form-control {
   }
 
   h2 {
-    padding: 0;
+    padding: 15px 0;
     margin: 0;
     color: $text-colour;
+    font-size: 24px;
   }
 
   #progress-panel {

--- a/app/views/pqs/_answer.html.slim
+++ b/app/views/pqs/_answer.html.slim
@@ -1,3 +1,4 @@
+h2 Answer
 .form-group
   label.form-label for="answer_submitted"  Date answer submitted
   .datetimepicker

--- a/app/views/pqs/_com_data.html.slim
+++ b/app/views/pqs/_com_data.html.slim
@@ -1,3 +1,4 @@
+h2 PQ commission
 .deadline_input.form-group
   label.form-label for="pq_internal_deadline"
     | Internal deadline#{render partial: 'shared/deadline_time', locals: {internal_deadline: @pq.internal_deadline, is_closed: @pq.closed?, draft_reply: @pq.draft_answer_received }}

--- a/app/views/pqs/_fc_data.html.slim
+++ b/app/views/pqs/_fc_data.html.slim
@@ -1,3 +1,4 @@
+h2 Finance check
 = render partial: 'gds_checkbox', locals: { value: @pq.finance_interest,
                                             field: 'finance_interest',
                                             label: 'Finance interest' }

--- a/app/views/pqs/_minister_check.html.slim
+++ b/app/views/pqs/_minister_check.html.slim
@@ -1,3 +1,4 @@
+h2 Minister check
 #answeringminister
   .form-group
     label.form-label for="sent_to_answering_minister"  Date sent to answering minister

--- a/app/views/pqs/_pod_check.html.slim
+++ b/app/views/pqs/_pod_check.html.slim
@@ -1,3 +1,6 @@
+h2
+  abbr title="Private Office Directorate" POD 
+  'check
 h3
   ' Date sent to
   abbr title="Private Office Directorate" POD

--- a/app/views/pqs/_pq_data.html.slim
+++ b/app/views/pqs/_pq_data.html.slim
@@ -1,3 +1,4 @@
+h2 PQ Details
 h3
   abbr title="Unique Identification Number" UIN
 p.text= @pq.uin

--- a/app/views/pqs/_pq_draft.html.slim
+++ b/app/views/pqs/_pq_draft.html.slim
@@ -1,3 +1,4 @@
+h2 PQ draft
 - if @pq.action_officers.size > 0
   - @pq.action_officers_pqs.each do |ao_pq|
     - if ao_pq.accepted?

--- a/app/views/pqs/show.html.slim
+++ b/app/views/pqs/show.html.slim
@@ -29,7 +29,7 @@
             a#progress-menu-answer href="#progress-menu-answer-data" data-toggle="tab" Answer
     #progress-panel.col-md-9
       = form_for @pq, :url => { :action => "update", :id => @pq[:uin] }, :html=>{ :class=>'progress-menu-form' } do |f|
-        fieldset.tab-content
+        fieldset.tab-content role="region" aria-live="polite"
           #progress-menu-pq-data role="tabpanel" class="tab-pane active"
             = render partial:'pq_data', locals: {f: f}
           #progress-menu-fc-data role="tabpanel" class="tab-pane"

--- a/app/views/pqs/show.html.slim
+++ b/app/views/pqs/show.html.slim
@@ -8,29 +8,25 @@
   = render 'pq_header'
   #pq-detail-area.row
     #progress-menu.col-md-3
-      ul.nav.nav-tabs.nav-stacked data-tabs="tabs"
-        li.active
-          a#progress-menu-pq href="#progress-menu-pq-data" data-toggle="tab"
-            h2 PQ Details
-        li
-          a#progress-menu-fc href="#progress-menu-fc-data" data-toggle="tab"
-            h2 Finance check
-        li
-          a#progress-menu-com href="#progress-menu-com-data" data-toggle="tab"
-            h2 PQ commission
-        li
-          a#progress-menu-sub href="#progress-menu-sub-data" data-toggle="tab"
-            h2 PQ draft
-        li
-          a#progress-menu-pod href="#progress-menu-pod-data" data-toggle="tab"
-            h2
+      nav
+        p.visually-hidden Jump to a section...
+        ul.nav.nav-tabs.nav-stacked data-tabs="tabs"
+          li.active
+            a#progress-menu-pq href="#progress-menu-pq-data" data-toggle="tab" PQ Details
+          li
+            a#progress-menu-fc href="#progress-menu-fc-data" data-toggle="tab" Finance check
+          li
+            a#progress-menu-com href="#progress-menu-com-data" data-toggle="tab" PQ commission
+          li
+            a#progress-menu-sub href="#progress-menu-sub-data" data-toggle="tab" PQ draft
+          li
+            a#progress-menu-pod href="#progress-menu-pod-data" data-toggle="tab"
               abbr title="Private Office Directorate" POD 
-              ' check
-        li
-          a#progress-menu-min href="#progress-menu-min-data" data-toggle="tab"
-            h2 Minister check
-        li
-          a#progress-menu-answer href="#progress-menu-answer-data" data-toggle="tab" Answer
+              'check
+          li
+            a#progress-menu-min href="#progress-menu-min-data" data-toggle="tab" Minister check
+          li
+            a#progress-menu-answer href="#progress-menu-answer-data" data-toggle="tab" Answer
     #progress-panel.col-md-9
       = form_for @pq, :url => { :action => "update", :id => @pq[:uin] }, :html=>{ :class=>'progress-menu-form' } do |f|
         fieldset.tab-content


### PR DESCRIPTION
## Description
Make PQ Details headings be with content rather than grouped before. Instead let Nav be grouped before for skip-to links when CSS/JS disabled.
Note that I've added ARIA live region for now for changing content because a JS library is already being used. Ideally we should use a library that supports ARIA - and then use ARIA tabs properly - but that would be a separate ticket and probably not a requirement, just a nice to have.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
No styles view:
Before:
![image](https://user-images.githubusercontent.com/22935203/164045716-5a069f20-745c-4d5a-ba6a-88b6c886b7aa.png)


After:
![image](https://user-images.githubusercontent.com/22935203/164040664-6a87ce4e-0af5-4feb-81d5-332fd1e984ab.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3836

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Disable styles and JavaScript and go to PQ show page.
