### PR TITLE
CT-3845 Add gap above flag for PQ detail

### DIFF
--- a/app/assets/stylesheets/pq.scss
+++ b/app/assets/stylesheets/pq.scss
@@ -703,7 +703,7 @@ textarea.form-control {
     }
   }
 
-  #pq-details-qa-link { display: block; }
+  #pq-details-qa-link { display: block; padding-top: 5px; }
 
   ul.nav-tabs li a {
     outline: 0;


### PR DESCRIPTION
## Description
Slight gap needed above flag to fix for mobile view

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
Before:
<img width="411" alt="image" src="https://user-images.githubusercontent.com/22935203/164271271-e634e7fc-d132-4c42-b294-0b03120553b2.png">


After:
<img width="395" alt="image" src="https://user-images.githubusercontent.com/22935203/164271325-54573cb9-f5be-4b7b-8b94-2bb684562254.png">



### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3845

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Go to PQ detail page with QA tool link and reduce to mobile.
