### PR TITLE
CT-3869 Move filters above content as per homepage

### DIFF
--- a/app/views/reports/filter_all.html.slim
+++ b/app/views/reports/filter_all.html.slim
@@ -5,17 +5,7 @@ div#filter-report
   h1 PQ filter
   = render partial: 'shared/flash_messages'
   .row
-    .col-md-9
-      - if @questions.empty?
-        h2 Please select a filter option
-      - else
-        p.count
-          = pluralize(@questions.total_entries,'Question') + ' found'
-        ul.questions-list
-          - @questions.each do |question|
-            li id="pq-frame-#{question.id}"
-              = render partial: 'dashboard/question_data', locals: {question: question, action_officers: @action_officers}
-    .col-md-3
+    .col-md-3.col-md-push-9
       = form_tag({controller: 'reports', action: 'filter_all'}, {:method => :get}) do
         .form-group
           label.form-label for="minister_id"  Minister
@@ -29,6 +19,16 @@ div#filter-report
         .form-group
           = submit_tag 'Filter' , class: 'button' , :onclick=> "ga('send', 'event', 'reports', 'view', 'pq filter')"
           = link_to 'Show all', filter_all_path, class: 'button-secondary'
+    .col-md-9.col-md-pull-3
+      - if @questions.empty?
+        h2 Please select a filter option
+      - else
+        p.count
+          = pluralize(@questions.total_entries,'Question') + ' found'
+        ul.questions-list
+          - @questions.each do |question|
+            li id="pq-frame-#{question.id}"
+              = render partial: 'dashboard/question_data', locals: {question: question, action_officers: @action_officers}
   - if @questions.any?
     #pages.row
       = will_paginate @questions, {class: 'col-md-9'}


### PR DESCRIPTION
## Description
CT-3869 Move filters above content as per homepage

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
n / a

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3869

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Squash to mobile portrait view on Filters page after clicking anything on reports. Filters should show at the top of the screen instead of bottom.
