### PR TITLE
CT-3824 reorganise action officer reminder text

### DIFF
--- a/app/views/dashboard/_question_data_commissioned.html.slim
+++ b/app/views/dashboard/_question_data_commissioned.html.slim
@@ -14,6 +14,7 @@
   span.replying-minister
     = question.minister.name
   - if question.policy_minister
+    span = ' '
     h3 Policy minister:
     span.policy-minister
       = question.policy_minister.name
@@ -25,6 +26,9 @@
     - question.action_officers_pqs.each do | ao_pq |
       - if !ao_pq.rejected? && !ao_pq.action_officer.nil?
         = link_to ao_pq.action_officer.name, action_officer_path(ao_pq.action_officer)
+        span = ' | '
+    - question.action_officers_pqs.each do | ao_pq |
+      div
         a<>
         = render partial: 'shared/ao_reminder_link', locals: {ao_pq: ao_pq, question: question}
         a>

--- a/app/views/shared/_ao_reminder_link.html.slim
+++ b/app/views/shared/_ao_reminder_link.html.slim
@@ -4,5 +4,5 @@
 - elsif ao_pq.rejected?
   /! rejected
 - else
-  - reminder_accept_count =  ao_pq.reminder_accept > 0 ? " (#{ao_pq.reminder_accept})" : ''
-  = link_to raw("<span class=\"fa fa-envelope-o\"></span> Send reminder#{reminder_accept_count}"), {controller: 'action_officer_reminder', action: 'accept_reject', id: ao_pq.id, remote: true}, {class: 'ao-reminder-link', title: 'Send an accept/reject reminder email'}
+  - reminder_accept_count =  ao_pq.reminder_accept > 0 ? " (#{ao_pq.reminder_accept} already sent)" : ''
+  = link_to raw("<span class=\"fa fa-envelope-o\"></span> Send reminder to #{ao_pq.action_officer.name} #{reminder_accept_count}"), {controller: 'action_officer_reminder', action: 'accept_reject', id: ao_pq.id, remote: true}, {class: 'ao-reminder-link' }


### PR DESCRIPTION
## Description
Make action officers and reminders a bit clearer and links more accessible

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
before: 
<img width="690" alt="image" src="https://user-images.githubusercontent.com/22935203/167827359-82d519d8-9421-4b16-a2f0-b748a54564ed.png">


after:

<img width="638" alt="image" src="https://user-images.githubusercontent.com/22935203/167827238-e0621c42-4e60-4828-a3b3-a111f48b974e.png">


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3824

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
View PQs on the list pages New, In Progress, Filters
