### PR TITLE
CDPT-487 Adjust probes to prevent restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ postgres.log
 set_env.sh
 tmp
 vendor
+*secret*.*

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ function _build() {
   aws_profile='ecr-live-parliamentary-questions'
 
   git_remote_url="https://github.com/ministryofjustice/parliamentary-questions.git";
-  docker_endpoint=754256621582.dkr.ecr.eu-west-2.amazonaws.com/pq-team/parliamentary-questions:pq-main-e15d73ca
+  docker_endpoint=754256621582.dkr.ecr.eu-west-2.amazonaws.com
   docker_registry=${docker_endpoint}/${team_name}/${ecr_repo_name}
 
   current_branch=$(git branch | grep \* | cut -d ' ' -f2)

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ function _build() {
   aws_profile='ecr-live-parliamentary-questions'
 
   git_remote_url="https://github.com/ministryofjustice/parliamentary-questions.git";
-  docker_endpoint=754256621582.dkr.ecr.eu-west-2.amazonaws.com
+  docker_endpoint=754256621582.dkr.ecr.eu-west-2.amazonaws.com/pq-team/parliamentary-questions:pq-main-e15d73ca
   docker_registry=${docker_endpoint}/${team_name}/${ecr_repo_name}
 
   current_branch=$(git branch | grep \* | cut -d ' ' -f2)

--- a/k8s-deploy/development/deployment_sidekiq.yaml
+++ b/k8s-deploy/development/deployment_sidekiq.yaml
@@ -59,13 +59,19 @@ spec:
                 - /bin/sh
                 - -c
                 - 'sidekiqmon | grep "parliamentary-questions"'
-            initialDelaySeconds: 40
-            periodSeconds: 60
+            initialDelaySeconds: 30
+            periodSeconds: 90
+            timeoutSeconds: 15
+            successThreshold: 1
+            failureThreshold: 3
           livenessProbe:
             exec:
               command:
                 - /bin/sh
                 - -c
                 - 'sidekiqmon | grep "parliamentary-questions"'
-            initialDelaySeconds: 40
-            periodSeconds: 60
+            initialDelaySeconds: 30
+            periodSeconds: 90
+            timeoutSeconds: 15
+            successThreshold: 1
+            failureThreshold: 3

--- a/k8s-deploy/production/deployment_sidekiq.yaml
+++ b/k8s-deploy/production/deployment_sidekiq.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       containers:
         - name: parliamentary-questions-rails-jobs
-          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/pq-team/parliamentary-questions:pq-main-e15d73ca
           command: ["./docker/entrypoint-background-jobs.sh"]
           env:
             - name: DB_HOST

--- a/k8s-deploy/production/deployment_sidekiq.yaml
+++ b/k8s-deploy/production/deployment_sidekiq.yaml
@@ -21,6 +21,7 @@ spec:
     spec:
       containers:
         - name: parliamentary-questions-rails-jobs
+          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/pq-team/parliamentary-questions:pq-main-e15d73ca
           command: ["./docker/entrypoint-background-jobs.sh"]
           env:
             - name: DB_HOST
@@ -59,13 +60,19 @@ spec:
                 - /bin/sh
                 - -c
                 - 'sidekiqmon | grep "parliamentary-questions"'
-            initialDelaySeconds: 40
-            periodSeconds: 60
+            initialDelaySeconds: 30
+            periodSeconds: 90
+            timeoutSeconds: 15
+            successThreshold: 1
+            failureThreshold: 3
           livenessProbe:
             exec:
               command:
                 - /bin/sh
                 - -c
                 - 'sidekiqmon | grep "parliamentary-questions"'
-            initialDelaySeconds: 40
-            periodSeconds: 60
+            initialDelaySeconds: 30
+            periodSeconds: 90
+            timeoutSeconds: 15
+            successThreshold: 1
+            failureThreshold: 3

--- a/k8s-deploy/staging/deployment_sidekiq.yaml
+++ b/k8s-deploy/staging/deployment_sidekiq.yaml
@@ -59,13 +59,19 @@ spec:
                 - /bin/sh
                 - -c
                 - 'sidekiqmon | grep "parliamentary-questions"'
-            initialDelaySeconds: 40
-            periodSeconds: 60
+            initialDelaySeconds: 30
+            periodSeconds: 90
+            timeoutSeconds: 15
+            successThreshold: 1
+            failureThreshold: 3
           livenessProbe:
             exec:
               command:
                 - /bin/sh
                 - -c
                 - 'sidekiqmon | grep "parliamentary-questions"'
-            initialDelaySeconds: 40
-            periodSeconds: 60
+            initialDelaySeconds: 30
+            periodSeconds: 90
+            timeoutSeconds: 15
+            successThreshold: 1
+            failureThreshold: 3


### PR DESCRIPTION
## Description
Adjust probes to allow some leeway for sidekiq to respond before restarting pod.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPT-487

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
