### PR TITLE
CDPT-389: Reduce staging environment pods from 4 to 1

### DIFF
--- a/k8s-deploy/staging/deployment.yaml
+++ b/k8s-deploy/staging/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app: parliamentary-questions
   name: parliamentary-questions
 spec:
-  replicas: 4
+  replicas: 1
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
PQ Tracking - staging environment has 4 pods and other ruby apps staging environments have only 1.  After a review with Nick and Javid we decided to reduce to 1.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
