### PR TITLE
CDPT-876 Fix incorrect PQ state change.

### DIFF
--- a/lib/pq_state/progress_changer.rb
+++ b/lib/pq_state/progress_changer.rb
@@ -15,11 +15,13 @@ module PQState
       end,
       ## With POD
       Transition(DRAFT_PENDING, WITH_POD) do |pq|
-        !pq.draft_answer_received.nil?
+        # !pq.draft_answer_received.nil?
+        !!pq.draft_answer_received # rubocop:disable Style/DoubleNegation
       end,
       ## POD Query
       Transition(WITH_POD, POD_QUERY) do |pq|
-        !pq.pod_query_flag.nil?
+        # !pq.pod_query_flag.nil?
+        !!pq.pod_query_flag # rubocop:disable Style/DoubleNegation
       end,
       ## POD Clearance
       Transition.factory([WITH_POD, POD_QUERY], [POD_CLEARED]) do |pq|

--- a/lib/pq_state/progress_changer.rb
+++ b/lib/pq_state/progress_changer.rb
@@ -15,12 +15,10 @@ module PQState
       end,
       ## With POD
       Transition(DRAFT_PENDING, WITH_POD) do |pq|
-        # !pq.draft_answer_received.nil?
         !!pq.draft_answer_received # rubocop:disable Style/DoubleNegation
       end,
       ## POD Query
       Transition(WITH_POD, POD_QUERY) do |pq|
-        # !pq.pod_query_flag.nil?
         !!pq.pod_query_flag # rubocop:disable Style/DoubleNegation
       end,
       ## POD Clearance
@@ -30,9 +28,9 @@ module PQState
       ## With Minister
       Transition(POD_CLEARED, WITH_MINISTER) do |pq|
         if !pq.policy_minister
-          !pq.sent_to_answering_minister.nil?
+          !!pq.sent_to_answering_minister # rubocop:disable Style/DoubleNegation
         else
-          !(pq.sent_to_answering_minister && pq.sent_to_policy_minister).nil?
+          !!(pq.sent_to_answering_minister && pq.sent_to_policy_minister) # rubocop:disable Style/DoubleNegation
         end
       end,
       ## Minister Query


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
Applying the RuboCop auto-correct to PQ made changes to the progress_changer.rb code.  These changes have cause some state changes to be skipped e.g. "Draft Pending" => "POD Query" instead of "With POD".  This PR reverts the changes and disables the RuboCop Style/DoubleNegation check on the effected lines.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->
N/A

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/864?modal=detail&selectedIssue=CDPT-876

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->
N/A
### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
1. Commission a question where you are the Action Officer.
2. Accept the assignment via the Allocation email.  The PQ status should now read "Draft Pending"
3. Go to the "In progress" tab.
4. Click on the "PQ draft" tad (left hand side)
5. Under "Date PQ returned by action officer" enter a date and time.
6. Click on Save.
7. The PQ stage should now be changed to "With POD" not "POD query"
