### PR TITLE
Move Sinatra out of test group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem "select2-rails", "~> 4.0", ">= 4.0.13"
 gem "sentry-rails", "~> 5.2"
 gem "sentry-ruby", "~> 5.2"
 gem "sidekiq", "~> 6.5"
+gem "sinatra", "~> 3.1", require: false
 gem "slim", "~> 5.1"
 gem "statsd-ruby", "~> 1.5"
 gem "turbolinks", "~> 5.2", ">= 5.2.1"
@@ -60,7 +61,6 @@ group :test, :development do
   gem "rspec-rails", "~> 6.0"
   gem "rubocop-govuk", require: false
   gem "shoulda-matchers", "~> 5.1", require: false
-  gem "sinatra", "~> 3.1"
   gem "timecop", "~> 0.9.5"
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ require "./spec/support/unit/question_factory"
 require "./spec/support/csv_helpers"
 require "shoulda/matchers"
 require "paper_trail/frameworks/rspec"
+require "sinatra"
 
 require "bundler/setup"
 ::Bundler.require(:default, :test)


### PR DESCRIPTION
## Description
Sinatra was only in the test group in the Gemfile, and a recent change excluded test dependencies when building the production image. Moving it out of the test group means it will be in the build.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
