### PR TITLE
Tell screen reader that HTML <a> tag acts as a <button>

### DIFF
--- a/app/views/shared/_navigation.html.slim
+++ b/app/views/shared/_navigation.html.slim
@@ -23,7 +23,7 @@
               = link_to 'Backlog', dashboard_backlog_path, action: 'backlog'
 
             li.dropdown class=('active' if @page_title == 'Minister report - Parliamentary Questions - Ministry of Justice' || @page_title == 'Press desk report - Parliamentary Questions - Ministry of Justice')
-              a.dropdown-toggle data-toggle="dropdown" data-target="#-" href="#"
+              a.dropdown-toggle data-toggle="dropdown" data-target="#-" href="#" aria-haspopup="true" role="button"
                 | Reports
                 span.caret
               ul.dropdown-menu role="menu"


### PR DESCRIPTION
## Description
Style changes in response to the PQ Tracker accessibility audit Dec 2022. Section 1.6

It was recommended to change the Report nav dropdown `<a>` tag to `<button>`. However, Bootstrap allows for a `role` attribute for accessibility reader assist which will read the `<a>` as a `<button>` https://getbootstrap.com/docs/5.3/components/buttons/#button-tags - see Button Tags section

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
