### PR TITLE
Allow screen reader to announce dynamic changes when filtered

### DIFF
--- a/app/assets/stylesheets/pq.scss
+++ b/app/assets/stylesheets/pq.scss
@@ -14,7 +14,7 @@ $danger-colour: $error-colour;
 body, main {
   font-size: 1.9rem;
   line-height: 1.3;
-  color: $text-colour; 
+  color: $text-colour;
 }
 
 h1 {
@@ -77,7 +77,7 @@ label {
 // = GLOBAL CLASSES ============================================================
 //==============================================================================
 
-#contentOuter { margin: 0 auto; max-width: 960px; } 
+#contentOuter { margin: 0 auto; max-width: 960px; }
 
 .row { margin: 0; }
 
@@ -341,7 +341,7 @@ textarea.form-control {
   border-left: 5px solid $border-colour;
   margin: .5em 0;
 }
-  
+
 .questions-list {
   padding: 0 0 20px;
   > li {
@@ -463,7 +463,7 @@ textarea.form-control {
   }
 }
 
-@media screen and (max-width: 641px) { 
+@media screen and (max-width: 641px) {
   #admin-button-bar {
     float: none;
     li {
@@ -475,7 +475,7 @@ textarea.form-control {
 
 // = Allocation rejection control ==================================================
 /* used to show/hide allocation rejections*/
-.question-allocation-list details .panel-indent { 
+.question-allocation-list details .panel-indent {
   border-left: 5px solid #eee;
   padding-left: .5em;
   margin-top: .5em;
@@ -759,7 +759,7 @@ textarea.form-control {
 
   #sidebar {
     padding: 0;
-    h2 {  
+    h2 {
       font-size: 1.9rem;
       padding: 0;
     }
@@ -785,7 +785,6 @@ textarea.form-control {
       .form-control:focus {
         outline: 3px solid -webkit-focus-ring-color;
         border-radius: 1px;
-        background-color: $yellow;
       }
       .form-control:focus::placeholder {
         color: #0b0c0c;
@@ -864,7 +863,7 @@ textarea.form-control {
         .collapsed { display: none; }
         .content {
           .form-group { margin-bottom: 0; }
-          > label { 
+          > label {
             margin-top: $gutter-half;
           }
           .list {
@@ -897,11 +896,11 @@ textarea.form-control {
   }
 }
 
-#footer .footer-meta { 
+#footer .footer-meta {
   .copyright {
     font-size: 1.6rem;
   }
-  .footer-meta-inner { 
+  .footer-meta-inner {
     ul, .open-government-licence p {
       font-size: 1.6rem;
     }

--- a/app/assets/stylesheets/pq.scss
+++ b/app/assets/stylesheets/pq.scss
@@ -779,8 +779,16 @@ textarea.form-control {
         .collapsed { display: none; }
       }
       .datepicker, .datetimepicker {
-        background-color: $white ;
+        background-color: $white;
         width: 100%;
+      }
+      .form-control:focus {
+        outline: 3px solid -webkit-focus-ring-color;
+        border-radius: 1px;
+        background-color: $yellow;
+      }
+      .form-control:focus::placeholder {
+        color: #0b0c0c;
       }
       .button-area {
         width: 100%;

--- a/app/views/dashboard/_questions_list.html.slim
+++ b/app/views/dashboard/_questions_list.html.slim
@@ -1,6 +1,6 @@
 .col-md-9.col-md-pull-3
   = render partial: "shared/flash_messages", flash: flash
-  #count
+  #count aria-live='polite'
     strong #{@questions.length}
     = ' '
     span parliamentary questions

--- a/app/views/shared/_navigation.html.slim
+++ b/app/views/shared/_navigation.html.slim
@@ -44,7 +44,7 @@
                 = text_field_tag :search, params[:search], { :id => 'search_field',  :class => 'form-control' }
                 = button_tag(:type => 'submit', :id => 'search_button', :class => 'btn btn-default') do
                   span.fa.fa-search
-                    span.visually-hidden Go
+                    span.visually-hidden Search
 
         - elsif current_user.finance_user?
           ul.nav.navbar-nav


### PR DESCRIPTION
## Description
Style changes in response to the PQ Tracker accessibility audit Dec 2022. Sections 1.11, 1.4, 1.5.

1.4 - added `aria-live="polite"` to `#count` element as a means to inform the screen reader that the number of filtered results has changed. Otherwise too much content will be read out. Example, the screen reader will read out "0 parliamentary questions out of 1." when filter results are updated.

1.5 - Added contrast to focus indicator on `filter` inputs (E.g. datepicker and keywords). Other dropdown contrasts were added in PR https://github.com/ministryofjustice/parliamentary-questions/pull/955

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots

![Screenshot 2023-09-13 at 09 02 42](https://github.com/ministryofjustice/parliamentary-questions/assets/129938801/4157a5c2-73ce-47ba-95b6-4c366751ad1c)
![Screenshot 2023-09-13 at 09 03 15](https://github.com/ministryofjustice/parliamentary-questions/assets/129938801/9033ad66-6a45-45c3-ae0a-e78198c1fa49)


### Related JIRA tickets
https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/1152?modal=detail&selectedIssue=CDPT-519

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
