### PR TITLE
Add label to link purpose for screen reader

### DIFF
--- a/app/views/dashboard/_question_data.html.slim
+++ b/app/views/dashboard/_question_data.html.slim
@@ -1,7 +1,7 @@
 .pq-header.row
   .col-md-5
-    h2 
-      = link_to(question.uin, { controller: 'pqs', action: 'show', id: question.uin}, :class=>"question-uin")
+    h2
+      = link_to(question.uin, { controller: 'pqs', action: 'show', id: question.uin}, :class=>"question-uin", aria: { label: "Click to view and edit question #{question.uin}" })
       span.question-type  = question.question_type_header
 
     label.pq-select for="#{question.uin}"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -24,7 +24,7 @@
 - content_for :proposition_header do
   .header-proposition
     .content
-      a#proposition-name href="/" PQ Tracker
+      a#proposition-name href="/" aria-label="click to navigate to PQ dashboard" PQ Tracker
 
 - content_for :content do
   main#contentOuter(role="main")

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -50,11 +50,11 @@
 - content_for :footer_support_links do
   ul
     li
-      = link_to "Accessibility", "/accessibility"
+      = link_to "Accessibility", "/accessibility", aria: { label: "click to visit accessibility statement"}
     li
-      = link_to "Contact Parliamentary Branch", "mailto:pqs@justice.gsi.gov.uk?Subject=PQ%20Tracker"
+      = link_to "Contact Parliamentary Branch", "mailto:pqs@justice.gsi.gov.uk?Subject=PQ%20Tracker", aria: { label: "click to email parliamentary branch"}
     li
-      <span>Built by</span> <a href="https://mojdigital.blog.gov.uk/"><abbr title="Ministry of Justice">MOJ</abbr> Digital Services</a>
+      <span>Built by</span> <a href="https://mojdigital.blog.gov.uk/" aria-label="click to visit justice digital blog"><abbr title="Ministry of Justice">MOJ</abbr> Digital Services</a>
 
 - content_for :body_end
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -32,9 +32,9 @@
       / p.phase-tag = config_item(:phase).upcase )(this line is kept incase the moj elements change and this line needs to be reinstated!)
       <span>Help make this service better - your&nbsp;
       - if ! user_signed_in?
-        <a href="mailto:pqsupport@digital.justice.gov.uk?Subject=PQ%20Feedback">feedback</a>&nbsp;
+        <a href="mailto:pqsupport@digital.justice.gov.uk?Subject=PQ%20Feedback" aria-label="Click to send feedback via email">feedback</a>&nbsp;
       - else
-        <a href="mailto:pqsupport@digital.justice.gov.uk?Subject=PQ%20Tracker">feedback</a>&nbsp;
+        <a href="mailto:pqsupport@digital.justice.gov.uk?Subject=PQ%20Tracker" aria-label="Click to send feedback via email">feedback</a>&nbsp;
       | will help us to improve it.
       </span>
 

--- a/app/views/reports/report.html.slim
+++ b/app/views/reports/report.html.slim
@@ -6,7 +6,7 @@ div#minister-report
         th scope="col" Progress
         - @report.header_cells.each do |c|
           th.table-cell-centered scope="col"
-            = link_to(c.label, c.path)
+            = link_to(c.label, c.path, aria: { label: "Click to view questions for #{c.label}" })
     tbody
       - @report.rows.each do |r|
         tr data="report-state-#{r.state}"
@@ -15,6 +15,6 @@ div#minister-report
           - r.cells.each do |c|
             td.table-cell-centered
               - unless c.zero?
-                = link_to(c.count, c.path)
+                = link_to(c.count, c.path, aria: { label: "Click to view questions with a status of #{r.label}" })
               - else
                 | 0

--- a/app/views/shared/_navigation.html.slim
+++ b/app/views/shared/_navigation.html.slim
@@ -14,13 +14,13 @@
 
           ul.nav.navbar-nav
             li class=('active' if @dashboard_state == 'New')
-              = link_to 'New', dashboard_path, action: 'index'
+              = link_to 'New', dashboard_path, action: 'index', aria: { label: "Click to view new questions"}
 
             li class=('active' if @dashboard_state == 'In progress')
-              = link_to 'In progress', dashboard_in_progress_path, action: 'in_progress'
+              = link_to 'In progress', dashboard_in_progress_path, action: 'in_progress', aria: { label: "Click to view in progress questions"}
 
             li class=('active' if @dashboard_state == 'Backlog')
-              = link_to 'Backlog', dashboard_backlog_path, action: 'backlog'
+              = link_to 'Backlog', dashboard_backlog_path, action: 'backlog', aria: { label: "Click to view backlog questions"}
 
             li.dropdown class=('active' if @page_title == 'Minister report - Parliamentary Questions - Ministry of Justice' || @page_title == 'Press desk report - Parliamentary Questions - Ministry of Justice')
               a.dropdown-toggle data-toggle="dropdown" data-target="#-" href="#" aria-haspopup="true" role="button"
@@ -28,9 +28,9 @@
                 span.caret
               ul.dropdown-menu role="menu"
                 li
-                  = link_to 'Minister report', reports_ministers_by_progress_path , :onclick=> "ga('send', 'event', 'reports', 'view', 'Minister Report')"
+                  = link_to 'Minister report', reports_ministers_by_progress_path , :onclick=> "ga('send', 'event', 'reports', 'view', 'Minister Report')", aria: { label: "Click to view minister reports"}
                 li
-                  = link_to 'Press desk report', reports_press_desk_by_progress_path , :onclick=> "ga('send', 'event', 'reports', 'view', 'Press Desk Report')"
+                  = link_to 'Press desk report', reports_press_desk_by_progress_path , :onclick=> "ga('send', 'event', 'reports', 'view', 'Press Desk Report')", aria: { label: "Click to view press desk reports"}
 
             li#settings class=('active' if @page_title == 'Settings - Parliamentary Questions - Ministry of Justice')
               = link_to 'Settings', admin_path


### PR DESCRIPTION
## Description
Style changes in response to the PQ Tracker accessibility audit Dec 2022. Section 1.8

Using a screen reader the following is read aloud:
- Question details link reads "visited, link, view and edit question <_questionuid>"_
- PQ feedback links reads "link, click to send feedback via email, main"
- Navigation links which reads "visited, link, click to view <_nav-option_>"
- Report screen which reads "link, click to view questions for <_minister_name_>"
- Report screen table cells which reads "link, click to view questions with a status of <_report_status_>"
- Accessibility link in footer which reads "link, click to visit accessibility statement"
- Parliamentary branch link (which opens default emailer) in footer which reads "link, click to email parliamentary branch"
- MOJ digital services link in footer which reads "visited, link, click to visit justice digital blog"
- PQ tracker link in header which reads "visited, link, click to navigate to PQ dashboard"

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/1152?modal=detail&selectedIssue=CDPT-522

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
To activate the screen reader on mac CMD + F5