### PR TITLE
Use bundle exec on readiness/liveness check

### DIFF
--- a/k8s-deploy/development/deployment_sidekiq.yaml
+++ b/k8s-deploy/development/deployment_sidekiq.yaml
@@ -58,7 +58,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - 'sidekiqmon | grep "parliamentary-questions"'
+                - 'bundle exec sidekiqmon | grep "parliamentary-questions"'
             initialDelaySeconds: 30
             periodSeconds: 90
             timeoutSeconds: 15
@@ -69,7 +69,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - 'sidekiqmon | grep "parliamentary-questions"'
+                - 'bundle exec sidekiqmon | grep "parliamentary-questions"'
             initialDelaySeconds: 30
             periodSeconds: 90
             timeoutSeconds: 15

--- a/k8s-deploy/production/deployment_sidekiq.yaml
+++ b/k8s-deploy/production/deployment_sidekiq.yaml
@@ -58,7 +58,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - 'sidekiqmon | grep "parliamentary-questions"'
+                - 'bundle exec sidekiqmon | grep "parliamentary-questions"'
             initialDelaySeconds: 30
             periodSeconds: 90
             timeoutSeconds: 15
@@ -69,7 +69,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - 'sidekiqmon | grep "parliamentary-questions"'
+                - 'bundle exec sidekiqmon | grep "parliamentary-questions"'
             initialDelaySeconds: 30
             periodSeconds: 90
             timeoutSeconds: 15

--- a/k8s-deploy/staging/deployment_sidekiq.yaml
+++ b/k8s-deploy/staging/deployment_sidekiq.yaml
@@ -58,7 +58,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - 'sidekiqmon | grep "parliamentary-questions"'
+                - 'bundle exec sidekiqmon | grep "parliamentary-questions"'
             initialDelaySeconds: 30
             periodSeconds: 90
             timeoutSeconds: 15
@@ -69,7 +69,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - 'sidekiqmon | grep "parliamentary-questions"'
+                - 'bundle exec sidekiqmon | grep "parliamentary-questions"'
             initialDelaySeconds: 30
             periodSeconds: 90
             timeoutSeconds: 15


### PR DESCRIPTION
## Description
There was an issue on another application where calling sidekiqmon was not working without using `bundle exec` in some instances. Sidekiq is loaded from the Gemfile, so best practice is to use `bundle exec`.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
