### PR TITLE
Add table captions

### DIFF
--- a/app/views/action_officers/index.html.slim
+++ b/app/views/action_officers/index.html.slim
@@ -6,7 +6,7 @@ h1 Action officers
       li= link_to ('Add Action Officer'), new_action_officer_path, {class: 'button-secondary'}
       li= action_officer_toggle_link(@show_inactive)
 
-  table.table
+  table.table aria-label="action officers"
     thead
       tr
         th Name

--- a/app/views/actionlist_members/index.html.slim
+++ b/app/views/actionlist_members/index.html.slim
@@ -4,7 +4,7 @@ h1 Actionlist members
   .row
     ul#admin-button-bar
       li= link_to ('Add actionlist member'), new_actionlist_member_path, {class: 'button-secondary'}
-  table.table
+  table.table aria-label="actionlist members"
     thead
       tr
         th Name

--- a/app/views/deputy_directors/index.html.slim
+++ b/app/views/deputy_directors/index.html.slim
@@ -3,7 +3,7 @@ h1 Deputy directors
   .row
     ul#admin-button-bar
       li= link_to ('Add deputy director'), new_deputy_director_path, {class: 'button-secondary'}
-  table.table
+  table.table aria-label="deputy directors"
     thead
       tr
         th Name

--- a/app/views/directorates/index.html.slim
+++ b/app/views/directorates/index.html.slim
@@ -3,7 +3,7 @@ h1 Directorates
   .row
     ul#admin-button-bar
       li= link_to 'Add directorate', new_directorate_path, {class: 'button-secondary'}
-  table.table
+  table.table aria-label="directorates"
     thead
       tr
         th Name

--- a/app/views/divisions/index.html.slim
+++ b/app/views/divisions/index.html.slim
@@ -3,7 +3,7 @@ h1 Divisions
   .row
     ul#admin-button-bar
       li= link_to ('Add division'), new_division_path, {class: 'button-secondary'}
-  table.table
+  table.table aria-label="divisions"
     thead
       tr
         th Name

--- a/app/views/early_bird_members/index.html.slim
+++ b/app/views/early_bird_members/index.html.slim
@@ -6,7 +6,7 @@ h1 Early bird members
       li= link_to ('Send early bird info'), {controller: 'early_bird_send_emails', action: 'send_emails'}, {class: 'button', :onclick=> "ga('send', 'event', 'settings', 'earlybird', 'send early bird info');" }
       li= link_to ('Add early bird member'), new_early_bird_member_path, {class: 'button-secondary'}
       li= link_to ('Early bird preview'), {controller: 'early_bird_dashboard', action: 'preview'}, {class: 'button-secondary'}
-  table.table
+  table.table aria-label="early bird members"
     thead
       tr
         th Name

--- a/app/views/ministers/index.html.slim
+++ b/app/views/ministers/index.html.slim
@@ -3,7 +3,7 @@ h1 Ministers
   .row
     ul#admin-button-bar
       li= link_to ('Add minister'), new_minister_path, {class: 'button-secondary'}
-  table.table
+  table.table aria-label="ministers"
     thead
       tr
         th#minister-name Name

--- a/app/views/ogds/index.html.slim
+++ b/app/views/ogds/index.html.slim
@@ -3,7 +3,7 @@ h1 Other Government Departments
   div class="row"
     ul#admin-button-bar
       li= link_to ('Add Government Department'), new_ogd_path, {class: 'button-secondary'}
-  table.table
+  table.table aria-label="other government departments"
     thead
       tr
         th Name

--- a/app/views/press_desks/index.html.slim
+++ b/app/views/press_desks/index.html.slim
@@ -3,7 +3,7 @@ h1 Press desks
   div class="row"
     ul#admin-button-bar
       li= link_to ('Add press desk'), new_press_desk_path, {class: 'button-secondary'}
-  table.table
+  table.table aria-label="press desks"
     thead
       tr
         th Name

--- a/app/views/press_officers/index.html.slim
+++ b/app/views/press_officers/index.html.slim
@@ -3,7 +3,7 @@ h1 Press officers
   .row
     ul#admin-button-bar
       li= link_to ('Add press officer'), new_press_officer_path, {class: 'button-secondary'}
-  table.table
+  table.table aria-label="press officers"
     thead
       tr
         th Name

--- a/app/views/reports/report.html.slim
+++ b/app/views/reports/report.html.slim
@@ -1,6 +1,6 @@
 div#minister-report
   h1= @report.title
-  table.table.table-hover
+  table.table.table-hover aria-label="minister report"
     thead
       tr
         th scope="col" Progress

--- a/app/views/reports/report.html.slim
+++ b/app/views/reports/report.html.slim
@@ -1,6 +1,6 @@
 div#minister-report
   h1= @report.title
-  table.table.table-hover aria-label="minister report"
+  table.table.table-hover aria-label="#{@report.title}"
     thead
       tr
         th scope="col" Progress

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -4,7 +4,7 @@ h1 Users
   .row
     ul#admin-button-bar
       li= link_to 'Invite new user', new_user_invitation_path, {class: 'button-secondary'}
-  table.table
+  table.table aria-label="users"
     thead
       tr
         th Name

--- a/app/views/watchlist_members/index.html.slim
+++ b/app/views/watchlist_members/index.html.slim
@@ -6,7 +6,7 @@ h1 Watchlist members
       li= link_to ('Send allocation info'), {controller: 'watchlist_send_emails', action: 'send_emails'}, {class: 'button', :onclick=> "ga('send', 'event', 'settings', 'watchlist', 'send allocation info');" }
       li= link_to ('Add watchlist member'), new_watchlist_member_path, {class: 'button-secondary'}
       li= link_to ('Watchlist preview'), {controller: 'watchlist_dashboard', action: 'preview'}, {class: 'button-secondary'}
-  table.table
+  table.table aria-label="watchlist members"
     thead
       tr
         th Name


### PR DESCRIPTION
## Description
As per the accessibility audit, the screen reader should say which table the user is navigating into.

Using a `<caption>` element was recommended, however this created visible text then requiring a visually hidden class to be added. Instead, using aria-label on the table html tag works well.

Currently, when tabbing into a table, the screen reader says "Entering into table ...".

After the `aria-label` has been added:
When tabbing into the table, the screen reader now says "Entering into `<TABLENAME>` table ..."
When tabbing out of the table, the screen reader now says "Leaving `<TABLENAME>` ..."

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/1152?selectedIssue=CDPT-524 

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Tested using Macos CrossOver and WAVE evaluation browser extension