### PR TITLE
Clarify required fields

### DIFF
--- a/app/views/action_officers/_form.html.slim
+++ b/app/views/action_officers/_form.html.slim
@@ -3,11 +3,11 @@
     = render partial: 'shared/errors', object: @action_officer
     fieldset
       .form-group
-        label.form-label for="action_officer_name"  Name
+        label.form-label for="action_officer_name"  Name (required)
         = f.text_field :name, {class: 'form-control'}
       .form-group
-        label.form-label for="action_officer_email"  Email
-        = f.email_field :email , {class: 'form-control'}
+        label.form-label for="action_officer_email"  Email (required)
+        = f.email_field :email, {class: 'form-control'}
       .form-group
         label.form-label for="action_officer_group_email"  Group email
         = f.email_field :group_email , {class: 'form-control'}
@@ -15,10 +15,10 @@
         label.form-label for="action_officer_phone"  Phone
         = f.text_field :phone , {class: 'form-control'}
       .form-group
-        label.form-label for="action_officer_deputy_director_id"  Deputy Director
+        label.form-label for="action_officer_deputy_director_id"  Deputy Director (required)
         = f.collection_select(:deputy_director_id, @deputy_directors, :id, :name, :include_blank => "Please select")
       .form-group
-        label.form-label for="action_officer_press_desk_id"  Press Desk
+        label.form-label for="action_officer_press_desk_id"  Press Desk (required)
         = f.collection_select(:press_desk_id, @press_desks, :id, :name, :include_blank => "Please select")
       p Status
       .form-group

--- a/app/views/actionlist_members/_form.html.slim
+++ b/app/views/actionlist_members/_form.html.slim
@@ -3,10 +3,10 @@
     = render partial: 'shared/errors', object: @actionlist_member
     fieldset
       .form-group
-        label.form-label for="actionlist_member_name"  Name
+        label.form-label for="actionlist_member_name"  Name (required)
         = f.text_field :name, {class: 'form-control'}
       .form-group
-        label.form-label for="actionlist_member_email"  Email
+        label.form-label for="actionlist_member_email"  Email (required)
         = f.email_field :email , {class: 'form-control'}
       .form-group
         p Status:

--- a/app/views/deputy_directors/_form.html.slim
+++ b/app/views/deputy_directors/_form.html.slim
@@ -3,13 +3,13 @@
     = render partial: 'shared/errors', object: @deputy_director
     fieldset
       .form-group
-        label.form-label for="deputy_director_name"  Name
+        label.form-label for="deputy_director_name"  Name (required)
         = f.text_field :name, {class: 'form-control'}
       .form-group
-        label.form-label for="deputy_director_email"  Email
+        label.form-label for="deputy_director_email"  Email (required)
         = f.email_field :email, {class: 'form-control'}
       .form-group
-        label.form-label for="deputy_director_division_id"  Division
+        label.form-label for="deputy_director_division_id"  Division (required)
         = f.collection_select(:division_id, @divisions, :id, :name, :include_blank => "Please select")
       .form-group
         p Status

--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -3,7 +3,7 @@ h1.heading-large Forgot your password?
   = devise_error_messages!
   fieldset
     .form-group
-      label.form-label for="user_email"  Email
+      label.form-label for="user_email"  Email (required)
       = f.email_field :email, class: 'form-control', autofocus: true
     .form-group
       = f.submit "Send me reset password instructions", :class => 'button'

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,15 +1,15 @@
 - content_for :page_title do
-  = 'Sign in - ' 
+  = 'Sign in - '
 
 h1.heading-large Sign in
 = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
   = render partial: "shared/flash_messages", flash: flash
   = devise_error_messages!
   .form-group
-    label.form-label for="user_email"  Email
+    label.form-label for="user_email"  Email (required)
     = f.email_field :email, class: 'form-control', autofocus: true
   .form-group
-    label.form-label for="user_password"  Password
+    label.form-label for="user_password"  Password (required)
     = f.password_field :password, class: 'form-control', autocomplete: "off"
   .form-group
     - if devise_mapping.rememberable?

--- a/app/views/devise/unlocks/new.html.slim
+++ b/app/views/devise/unlocks/new.html.slim
@@ -2,7 +2,7 @@ h1.heading-large Resend unlock instructions
 = form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
   = devise_error_messages!
   .form-group
-    label.form-label for="user_email"  Email
+    label.form-label for="user_email"  Email (required)
     = f.email_field :email, class: 'form-control', autofocus: true
   .form-group
     = f.submit "Resend unlock instructions", :class => 'button'

--- a/app/views/directorates/_form.html.slim
+++ b/app/views/directorates/_form.html.slim
@@ -3,7 +3,7 @@
     = render partial: 'shared/errors', object: @directorate
     fieldset
       .form-group
-        label.form-label for="directorate_name"  Name
+        label.form-label for="directorate_name"  Name (required)
         = f.text_field :name, {class: 'form-control'}
       .form-group
         p Status

--- a/app/views/divisions/_form.html.slim
+++ b/app/views/divisions/_form.html.slim
@@ -3,10 +3,10 @@
     = render partial: 'shared/errors', object: @division
     fieldset
       .form-group
-        label.form-label for="division_name"  Name
+        label.form-label for="division_name"  Name (required)
         = f.text_field :name, {class: 'form-control'}
       .form-group
-        label.form-label for="division_directorate_id"  Directorate
+        label.form-label for="division_directorate_id"  Directorate (required)
         = f.collection_select(:directorate_id, @directorates, :id, :name, :include_blank => "Please select")
       .form-group
         p Status

--- a/app/views/early_bird_members/_form.html.slim
+++ b/app/views/early_bird_members/_form.html.slim
@@ -4,10 +4,10 @@
     - if @early_bird_member.errors.any?
     fieldset
       .form-group
-        label.form-label for="early_bird_member_name"  Name
+        label.form-label for="early_bird_member_name"  Name (required)
         = f.text_field :name, {class: 'form-control'}
       .form-group
-        label.form-label for="early_bird_member_email"  Email
+        label.form-label for="early_bird_member_email"  Email (required)
         = f.email_field :email , {class: 'form-control'}
       p Status
       .form-group

--- a/app/views/early_bird_organiser/_form.html.slim
+++ b/app/views/early_bird_organiser/_form.html.slim
@@ -5,10 +5,10 @@
     fieldset
       legend Select the dates between which you do not wish to receive the early bird email
       .form-group
-        label.form-label for="early_bird_organiser_date_from" First date to turn off the early bird email 
+        label.form-label for="early_bird_organiser_date_from" First date to turn off the early bird email (required)
         = f.date_field :date_from, {class: 'form-control'}
       .form-group
-        label.form-label for="early_bird_organiser_date_to" Last date the early bird email is off 
+        label.form-label for="early_bird_organiser_date_to" Last date the early bird email is off (required)
         = f.date_field :date_to , {class: 'form-control'}
       .form-group
         br

--- a/app/views/export/index.html.slim
+++ b/app/views/export/index.html.slim
@@ -1,5 +1,5 @@
 #csv-export
-  h1 
+  h1
     ' Export PQs to
     abbr title="Comma Separated Values" CSV
   = render partial: 'shared/flash_messages'
@@ -7,12 +7,12 @@
     fieldset
       legend Select the range of dates to do the export
       .form-group
-        label.form-label for="date_from"  Date from
+        label.form-label for="date_from"  Date from (required)
         .datepicker
           input#date_from.form-control name="date_from" type="text" value="04/06/2014" /
           span.fa.fa-calendar title="select a date"
       .form-group
-        label.form-label for="date_to"  Date to
+        label.form-label for="date_to"  Date to (required)
         .datepicker
           input#date_to.form-control name="date_to" type="text" value=Date.today.to_s(:date) /
           span.fa.fa-calendar title="select a date"

--- a/app/views/export/index_for_pod.html.slim
+++ b/app/views/export/index_for_pod.html.slim
@@ -1,6 +1,6 @@
 #csv-export
   h1
-    abbr title="Private Office Directorate" POD 
+    abbr title="Private Office Directorate" POD
     ' Export PQs to
     abbr title="Comma Separated Values" CSV
   = render partial: 'shared/flash_messages'
@@ -8,12 +8,12 @@
     fieldset
       legend Select the range of dates to do the export
       .form-group
-        label.form-label for="date_from"  Date from
+        label.form-label for="date_from"  Date from (required)
         .datepicker
           input#date_from.form-control name="date_from" type="text" value="04/06/2014" /
           span.fa.fa-calendar title="select a date"
       .form-group
-        label.form-label for="date_to"  Date to
+        label.form-label for="date_to"  Date to (required)
         .datepicker
           input#date_to.form-control name="date_to" type="text" value=Date.today.to_s(:date) /
           span.fa.fa-calendar title="select a date"

--- a/app/views/ministers/_form.html.slim
+++ b/app/views/ministers/_form.html.slim
@@ -13,7 +13,7 @@
           label.form-label for="minister_minister_contacts_attributes_0_name"  Contact description
           = ff.text_field :name, {class: 'form-control'}
         .form-group
-          label.form-label for="minister_minister_contacts_attributes_0_email"  Email
+          label.form-label for="minister_minister_contacts_attributes_0_email"  Email (required)
           = ff.email_field :email, {class: 'form-control'}
         .form-group
           label.form-label for="minister_minister_contacts_attributes_0_phone"  Phone

--- a/app/views/ogds/_form.html.slim
+++ b/app/views/ogds/_form.html.slim
@@ -3,10 +3,10 @@
     = render partial: 'shared/errors', object: @ogd
     fieldset
       .form-group
-        label.form-label for="ogd_name"  Name
+        label.form-label for="ogd_name"  Name (required)
         = f.text_field :name, {class: 'form-control'}
       .form-group
-        label.form-label for="ogd_acronym"  Acronym
+        label.form-label for="ogd_acronym"  Acronym (required)
         = f.text_field :acronym, {class: 'form-control'}
       .form-group
         p Status

--- a/app/views/press_desks/_form.html.slim
+++ b/app/views/press_desks/_form.html.slim
@@ -3,7 +3,7 @@
     = render partial: 'shared/errors', object: @press_desk
     fieldset
       .form-group
-        label.form-label for="press_desk_name"  Name
+        label.form-label for="press_desk_name"  Name (required)
         = f.text_field :name, {class: 'form-control'}
       .form-group
         p Status

--- a/app/views/press_officers/_form.html.slim
+++ b/app/views/press_officers/_form.html.slim
@@ -3,13 +3,13 @@
     = render partial: 'shared/errors', object: @press_officer
     fieldset
       .form-group
-        label.form-label for="press_officer_name"  Name
+        label.form-label for="press_officer_name"  Name (required)
         = f.text_field :name, {class: 'form-control'}
       .form-group
-        label.form-label for="press_officer_email"  Email
+        label.form-label for="press_officer_email"  Email (required)
         = f.email_field :email, {class: 'form-control'}
       .form-group
-        label.form-label for="press_officer_press_desk_id"  Press Desk
+        label.form-label for="press_officer_press_desk_id"  Press Desk (required)
         = f.collection_select(:press_desk_id, @press_offices, :id, :name, :include_blank => "Please select")
       .form-group
         p Status

--- a/app/views/transferred/_form.html.slim
+++ b/app/views/transferred/_form.html.slim
@@ -6,14 +6,14 @@
         label.form-label for="pq_uin"
           'Please enter the
           abbr title="Unique Identification Number" UIN
-          '  for the transferred PQ
+          '  for the transferred PQ (required)
 
         = f.text_field :uin, class:'form-control'
       .form-group
-        label.form-label for="pq_question"  Please enter the text of the question for the transferred PQ
+        label.form-label for="pq_question"  Please enter the text of the question for the transferred PQ (required)
         = f.text_area :question, cols: 40, rows: 5, class:'form-control'
       .form-group
-        label.form-label for="pq_dateforanswer"  Date for answer
+        label.form-label for="pq_dateforanswer"  Date for answer (required)
         .datetimepicker
           input#pq_dateforanswer.form-control.pq_dateforanswer name="pq[date_for_answer]" type="text" value=(@pq.date_for_answer.to_s) /
           span.fa.fa-calendar title="select a date"
@@ -51,7 +51,7 @@
         label.form-label for="pq_transfer_in_ogd_id"  Transferred in from
         = f.collection_select(:transfer_in_ogd_id, @ogd_list, :id, :name, :include_blank => "Select Department")
       .form-group
-        label.form-label for="transfer_in_date"  Date transferred in
+        label.form-label for="transfer_in_date"  Date transferred in (required)
         .datetimepicker
           input#transfer_in_date.form-control name="pq[transfer_in_date]" type="text" value=(@pq.transfer_in_date.to_s) /
           span.fa.fa-calendar title="select a date"

--- a/app/views/users/invitations/new.html.slim
+++ b/app/views/users/invitations/new.html.slim
@@ -3,10 +3,10 @@ h1= t "devise.invitations.new.header"
   = devise_error_messages!
   - resource.class.invite_key_fields.each do |field|
     .form-group
-      = f.label field
+      = f.label field, "Email (required)"
       = f.text_field field, {class: 'form-control'}
     .form-group
-      = f.label :name
+      = f.label :name, "Name (required)"
       = f.text_field :name, {class: 'form-control'}
     .form-group
       = f.label(:roles, 'Role')

--- a/app/views/watchlist_members/_form.html.slim
+++ b/app/views/watchlist_members/_form.html.slim
@@ -4,10 +4,10 @@
     - if @watchlist_member.errors.any?
     fieldset
       .form-group
-        label.form-label for="watchlist_member_name"  Name
+        label.form-label for="watchlist_member_name"  Name (required)
         = f.text_field :name, {class: 'form-control'}
       .form-group
-        label.form-label for="watchlist_member_email"  Email
+        label.form-label for="watchlist_member_email"  Email (required)
         = f.email_field :email , {class: 'form-control'}
       p Status
       .form-group


### PR DESCRIPTION
## Description
As per the accessibility report (1.9), required input fields should be clearly labelled and read by the screen reader. 

The report recommends adding the `required` attribute to the `<input>` tag, however this overwrites the currently used error notifications with the standard HTML5 browser input error notifications. 

Therefore, added "(required)" to form-group label to inform that it's a mandatory input, without having to be informed by the error notification after submitting the form.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/1152?selectedIssue=CDPT-529

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Tested using Macos VoiceOver