### PR TITLE
CDPT-528: Remove title element from 'Create 'I will write' follow up' link

### DIFF
--- a/app/views/pqs/_answer.html.slim
+++ b/app/views/pqs/_answer.html.slim
@@ -29,4 +29,4 @@ h2 Answer
                                             field: 'holding_reply_flag',
                                             label: 'Holding reply flag' }
 - unless @pq.is_follow_up?
-  = link_to ("Create 'I will write' follow up"), {controller: 'i_will_write', action: 'create', id: @pq.uin}, {id: 'create_iww', class: 'button-secondary', title: 'Create an ''I will write'' follow up'}
+  = link_to ("Create 'I will write' follow up"), {controller: 'i_will_write', action: 'create', id: @pq.uin}, {id: 'create_iww', class: 'button-secondary'}


### PR DESCRIPTION
## Description
9.5. Redundant content repeated by screen readers (L)

Create I will write follow up link highlighted on PQ details page

9.5.1. WCAG 1.3.1 (A) - Desktop
On the PQ details page, the “Create ‘I will write’ follow up” link has been assigned a title attribute which essentially repeats the text on the a element.
Repetitive content makes for auditory clutter, which can impose a cognitive load on screen reader users. As the wording in the title attribute doesn’t match up with the text on the a element, it may cause a jarring experience for some screen reader users with some vision.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
