### PR TITLE
Accurate tab labels

### DIFF
--- a/app/views/pqs/show.html.slim
+++ b/app/views/pqs/show.html.slim
@@ -5,23 +5,23 @@
   #pq-detail-area.row
     nav.col-md-3
       p.visually-hidden Jump to a section...
-      ul.nav.nav-stacked data-tabs="tabs"
+      ul.nav.nav-stacked data-tabs="tabs" role="tablist"
         li.active
-          a#progress-menu-pq href="#progress-menu-pq-data" data-toggle="tab" PQ Details
+          a#progress-menu-pq href="#progress-menu-pq-data" data-toggle="tab" role="tab" PQ Details
         li
-          a#progress-menu-fc href="#progress-menu-fc-data" data-toggle="tab" Finance check
+          a#progress-menu-fc href="#progress-menu-fc-data" data-toggle="tab" role="tab" Finance check
         li
-          a#progress-menu-com href="#progress-menu-com-data" data-toggle="tab" PQ commission
+          a#progress-menu-com href="#progress-menu-com-data" data-toggle="tab" role="tab" PQ commission
         li
-          a#progress-menu-sub href="#progress-menu-sub-data" data-toggle="tab" PQ draft
+          a#progress-menu-sub href="#progress-menu-sub-data" data-toggle="tab" role="tab" PQ draft
         li
-          a#progress-menu-pod href="#progress-menu-pod-data" data-toggle="tab"
-            abbr title="Private Office Directorate" POD 
+          a#progress-menu-pod href="#progress-menu-pod-data" data-toggle="tab" role="tab"
+            abbr title="Private Office Directorate" POD
             'check
         li
-          a#progress-menu-min href="#progress-menu-min-data" data-toggle="tab" Minister check
+          a#progress-menu-min href="#progress-menu-min-data" data-toggle="tab" role="tab" Minister check
         li
-          a#progress-menu-answer href="#progress-menu-answer-data" data-toggle="tab" Answer
+          a#progress-menu-answer href="#progress-menu-answer-data" data-toggle="tab" role="tab" Answer
     #progress-panel.col-md-9
       = form_for @pq, :url => { :action => "update", :id => @pq[:uin] }, :html=>{ :class=>'progress-menu-form' } do |f|
         fieldset.tab-content role="region" aria-live="polite"


### PR DESCRIPTION
## Description
As per the accessibility report 9.2, the tab panels within PQ details should be accurately described by the screenreader.

Currently, when tabbing over an element the screen reader says "link, Finance check"

After adding `role="tablist"` to the parent `ul` and `role="tab"` to each `li` element. The screen reader says e.g. "Finance check, selected, tab, 2 of 7". 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Tested with MacOs VoiceOver