### PR TITLE
Labels for status and warnings

### DIFF
--- a/app/views/dashboard/_question_data.html.slim
+++ b/app/views/dashboard/_question_data.html.slim
@@ -1,7 +1,7 @@
 .pq-header.row
   .col-md-5
     h2
-      = link_to(question.uin, { controller: 'pqs', action: 'show', id: question.uin}, :class=>"question-uin", aria: { label: "Click to view and edit question #{question.uin}, question status #{question.state}" })
+      = link_to(question.uin, { controller: 'pqs', action: 'show', id: question.uin}, :class=>"question-uin", aria: { label: "Click to view and edit question #{question.uin}, question status #{question.state.humanize}" })
       span.question-type  = question.question_type_header
 
     label.pq-select for="#{question.uin}"

--- a/app/views/dashboard/_question_data.html.slim
+++ b/app/views/dashboard/_question_data.html.slim
@@ -1,7 +1,7 @@
 .pq-header.row
   .col-md-5
     h2
-      = link_to(question.uin, { controller: 'pqs', action: 'show', id: question.uin}, :class=>"question-uin", aria: { label: "Click to view and edit question #{question.uin}, question status #{question.state.humanize}, deadline date #{question.internal_deadline}" })
+      = link_to(question.uin, { controller: 'pqs', action: 'show', id: question.uin}, :class=>"question-uin", aria: { label: "Click to view and edit question #{question.uin}, question status #{question.state.humanize}, deadline date #{question.internal_deadline || 'not set'}" })
       span.question-type  = question.question_type_header
 
     label.pq-select for="#{question.uin}"

--- a/app/views/dashboard/_question_data.html.slim
+++ b/app/views/dashboard/_question_data.html.slim
@@ -1,7 +1,7 @@
 .pq-header.row
   .col-md-5
     h2
-      = link_to(question.uin, { controller: 'pqs', action: 'show', id: question.uin}, :class=>"question-uin", aria: { label: "Click to view and edit question #{question.uin}, question status #{question.state.humanize}, deadline date #{question.internal_deadline || 'not set'}" })
+      = link_to(question.uin, { controller: 'pqs', action: 'show', id: question.uin}, :class=>"question-uin", aria: { label: "Click to view and edit question #{question.uin}, question status #{question.state.humanize}, internal deadline #{question.internal_deadline || 'not set'}" })
       span.question-type  = question.question_type_header
 
     label.pq-select for="#{question.uin}"

--- a/app/views/dashboard/_question_data.html.slim
+++ b/app/views/dashboard/_question_data.html.slim
@@ -1,7 +1,7 @@
 .pq-header.row
   .col-md-5
     h2
-      = link_to(question.uin, { controller: 'pqs', action: 'show', id: question.uin}, :class=>"question-uin", aria: { label: "Click to view and edit question #{question.uin} question status #{question.state}" })
+      = link_to(question.uin, { controller: 'pqs', action: 'show', id: question.uin}, :class=>"question-uin", aria: { label: "Click to view and edit question #{question.uin}, question status #{question.state}" })
       span.question-type  = question.question_type_header
 
     label.pq-select for="#{question.uin}"

--- a/app/views/dashboard/_question_data.html.slim
+++ b/app/views/dashboard/_question_data.html.slim
@@ -1,7 +1,7 @@
 .pq-header.row
   .col-md-5
     h2
-      = link_to(question.uin, { controller: 'pqs', action: 'show', id: question.uin}, :class=>"question-uin", aria: { label: "Click to view and edit question #{question.uin}, question status #{question.state.humanize}" })
+      = link_to(question.uin, { controller: 'pqs', action: 'show', id: question.uin}, :class=>"question-uin", aria: { label: "Click to view and edit question #{question.uin}, question status #{question.state.humanize}, deadline date #{question.internal_deadline}" })
       span.question-type  = question.question_type_header
 
     label.pq-select for="#{question.uin}"

--- a/app/views/dashboard/_question_data.html.slim
+++ b/app/views/dashboard/_question_data.html.slim
@@ -1,7 +1,7 @@
 .pq-header.row
   .col-md-5
     h2
-      = link_to(question.uin, { controller: 'pqs', action: 'show', id: question.uin}, :class=>"question-uin", aria: { label: "Click to view and edit question #{question.uin}" })
+      = link_to(question.uin, { controller: 'pqs', action: 'show', id: question.uin}, :class=>"question-uin", aria: { label: "Click to view and edit question #{question.uin} question status #{question.state}" })
       span.question-type  = question.question_type_header
 
     label.pq-select for="#{question.uin}"

--- a/app/views/dashboard/_questions_list.html.slim
+++ b/app/views/dashboard/_questions_list.html.slim
@@ -12,6 +12,6 @@
 
   ul.questions-list
     - questions.each do |question|
-      li id="pq-frame-#{question.id}" data-pquin=question.uin class="question"
+      li id="pq-frame-#{question.id}" data-pquin=question.uin class="question" aria-label="question status #{question.state}"
         = render partial: 'dashboard/question_data', locals: {question: question, action_officers: action_officers}
   #pages.row

--- a/app/views/dashboard/_questions_list.html.slim
+++ b/app/views/dashboard/_questions_list.html.slim
@@ -12,6 +12,6 @@
 
   ul.questions-list
     - questions.each do |question|
-      li id="pq-frame-#{question.id}" data-pquin=question.uin class="question" aria-label="question status #{question.state}"
+      li id="pq-frame-#{question.id}" data-pquin=question.uin class="question"
         = render partial: 'dashboard/question_data', locals: {question: question, action_officers: action_officers}
   #pages.row


### PR DESCRIPTION
## Description
As per the accessibility report, the screen reader doesn't describe the question status or internal deadline date e.g. "draft pending" and "12/02/2020 11:00"

Currently when tabbing into a question within the question list, the screen reader omits the question status and internal deadline date e.g. "… link, click to view and edit question < QUESTION NUMBER > …"

After adding an `aria-label` when tabbing into a question the screenreader dynamically says e.g. “… link, click to view and edit question 123, question status draft pending, internal deadline 12/02/2020 11:00 (or, 'internal deadline not set') …”

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/1152?selectedIssue=CDPT-532

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Tested using MacOs VoiceOver CMD + F5