### PR TITLE
CDPT:779 AO rejection history should always be shown.

### DIFF
--- a/app/services/commissioning_service.rb
+++ b/app/services/commissioning_service.rb
@@ -12,7 +12,6 @@ class CommissioningService
 
     ActiveRecord::Base.transaction do
       pq = build_pq(form)
-      pq.action_officers_pqs.destroy_all
       ao_pqs =
         form.action_officer_id.uniq.map do |ao_id|
           ActionOfficersPq.create!(

--- a/spec/services/commissioning_service_spec.rb
+++ b/spec/services/commissioning_service_spec.rb
@@ -82,7 +82,7 @@ describe CommissioningService do
       end
 
       it "sets the pqs' action officers" do
-        expect(@pq.action_officers).to eq([ao1, ao2]) # rubocop:disable RSpec/InstanceVariable
+        expect(@pq.action_officers).to eq([ao1, ao2, ao3]) # rubocop:disable RSpec/InstanceVariable
       end
     end
   end


### PR DESCRIPTION
## Description
CDPT-779: AO rejection history should always be shown.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPT-779?atlOrigin=eyJpIjoiM2I3M2M3MTU0NjZiNDFkYTlmMmNhMThjOTVlOWI1NGUiLCJwIjoiaiJ9

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
