### PR TITLE
CDOT-1082 Prefix last sessions questions with a 'b'.

### DIFF
--- a/lib/tasks/bugfix.rake
+++ b/lib/tasks/bugfix.rake
@@ -49,10 +49,9 @@ namespace :bugfix do
 
   desc "Prefix uins for previous session"
   task prefix_uins: :environment do
-    puts "Number of non-prefixed uins #{
-    Pq.where.not("uin SIMILAR TO '(#|[ESCAPE *]|$|^|~|£|a)%'").count} "
+    puts "Number of non-prefixed UINs #{Pq.where.not("uin SIMILAR TO '(#|[ESCAPE *]|$|^|~|£|a)%'").count} "
     Pq.where.not("uin SIMILAR TO '(#|[ESCAPE *]|$|^|~|£|a)%'").update_all("uin='b'||uin")
-    puts "Number of uins with £ prefix #{Pq.where('uin like ?', 'b%').count} "
-    puts "Post-update: Number of non-prefixed uins #{Pq.where.not("uin SIMILAR TO '(#|[ESCAPE *]|$|^|~|£|a|b)%'").count} "
+    puts "Number of UINs now with the 'b' prefix #{Pq.where('uin like ?', 'b%').count} "
+    puts "Post-update: Number of non-prefixed UINs #{Pq.where.not("uin SIMILAR TO '(#|[ESCAPE *]|$|^|~|£|a|b)%'").count} "
   end
 end

--- a/lib/tasks/bugfix.rake
+++ b/lib/tasks/bugfix.rake
@@ -50,9 +50,9 @@ namespace :bugfix do
   desc "Prefix uins for previous session"
   task prefix_uins: :environment do
     puts "Number of non-prefixed uins #{
-    Pq.where.not("uin SIMILAR TO '(#|[ESCAPE *]|$|^|~)%'").count} "
-    Pq.where.not("uin SIMILAR TO '(#|[ESCAPE *]|$|^|~)%'").update_all("uin='£'||uin")
-    puts "Number of uins with £ prefix #{Pq.where('uin like ?', '£%').count} "
-    puts "Post-update: Number of non-prefixed uins #{Pq.where.not("uin SIMILAR TO '(#|[ESCAPE *]|$|^|~|£)%'").count} "
+    Pq.where.not("uin SIMILAR TO '(#|[ESCAPE *]|$|^|~|£|a)%'").count} "
+    Pq.where.not("uin SIMILAR TO '(#|[ESCAPE *]|$|^|~|£|a)%'").update_all("uin='b'||uin")
+    puts "Number of uins with £ prefix #{Pq.where('uin like ?', 'b%').count} "
+    puts "Post-update: Number of non-prefixed uins #{Pq.where.not("uin SIMILAR TO '(#|[ESCAPE *]|$|^|~|£|a|b)%'").count} "
   end
 end


### PR DESCRIPTION
## Description
Parliament in now in recess and a new session will begin next week.  With each new session the question "Unique identifying number" (UIN) resets to 1, meaning there could be a clash between new and historical question numbers.  To avoid this, when a session closes and before another begins, the last sessions questions need to be prefixed with a unique character.  This sessions character is 'b'.  The prefix_uins script has to be updated with this character and run in Staging and Production environments

This script looks for and ignores all questions carrying previous prefix characters ('#', '$', '^', '~', '£', and 'a')and appends 'b' to the begining of all the rest of the questions. so for example:

£3456829
#2015019
$2015010
a2015011
2015012

would become:

£3456829
#2015019
$2015010
a2015011
b2015012

 ## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/1152?selectedIssue=CDPT-1082

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->
Nothing special

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
When run on Production all the last sessions questions should be prefixed with the letter 'b'.
