### PR TITLE
CDPT-901 Change cookie serializer

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,44 +3,6 @@
     {
       "warning_type": "Command Injection",
       "warning_code": 14,
-      "fingerprint": "0b238e6a2d9fa09e875c971e7bf8a12e07f06d00a1b579f3a97040ffe54b7b11",
-      "message": "Possible command injection",
-      "file": "lib/pqa/mock_api_server_runner.rb",
-      "line": 20,
-      "link": "http://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "Process.spawn(\"rackup -p #{PORT} -P #{PID_FILEPATH} #{RACK_CONFIG_PATH} &> #{LOG_FILEPATH}\", :chdir => (CWD))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "PQA::MockApiServerRunner",
-        "method": "start"
-      },
-      "user_input": "PORT",
-      "confidence": "Medium",
-      "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "0bac40d5de3ffb6f1762ebf3d36913285c3a2ebc43b2e23fad2febfafd870b44",
-      "message": "Possible SQL injection",
-      "file": "lib/pq_statistics/ao_churn.rb",
-      "line": 47,
-      "link": "http://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "ActiveRecord::Base.connection.execute(((\"SELECT FROM ( SELECT pq.id as pq_id, FROM pqs  pq \" + \"AND pq.created_at >= '#{bucket_dates.last.strftime(\"%Y-%m-%d\")}'::date \") + \"GROUP BY pq.id, pq.created_at, aopq_created_at \"))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "PqStatistics::AoChurn",
-        "method": "pq_data"
-      },
-      "user_input": "bucket_dates.last.strftime(\"%Y-%m-%d\")",
-      "confidence": "Medium",
-      "note": ""
-    },
-    {
-      "warning_type": "Command Injection",
-      "warning_code": 14,
       "fingerprint": "4c8abd2e60c229fa01041f3a6f4e90d3ca4a81c577cb6f44948e244652249a6f",
       "check_name": "Execute",
       "message": "Possible command injection",
@@ -62,110 +24,15 @@
       "note": ""
     },
     {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "5d69844e76884063a5133bd10db79048eb37feb149a1d1e2858a407cc9101bcb",
-      "message": "Possible SQL injection",
-      "file": "lib/pq_statistics/ao_churn.rb",
-      "line": 47,
-      "link": "http://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "ActiveRecord::Base.connection.execute(((\"SELECT FROM ( SELECT pq.id as pq_id, FROM pqs  pq \" + \"AND pq.created_at >= '#{bucket_dates.last.strftime(\"%Y-%m-%d\")}'::date \") + \"GROUP BY pq.id, pq.created_at, aopq_created_at \"))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "PqStatistics::AoChurn",
-        "method": "pq_data"
-      },
-      "user_input": "bucket_dates.last.strftime(\"%Y-%m-%d\")",
-      "confidence": "Medium",
-      "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "71cc79661ebd4a9ba1bb9a6194a7d9c1ba7e441b1b9ecf356a27512692590ee5",
-      "message": "Possible SQL injection",
-      "file": "lib/pq_statistics/time_to_assign.rb",
-      "line": 43,
-      "link": "http://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "ActiveRecord::Base.connection.execute(((\"SELECT pq.created_at as pq_created_at, \" + \"AND pq.created_at >= '#{bucket_dates.last.strftime(\"%Y-%m-%d\")}'::date \") + \"AND pq.follow_up_to is NULL GROUP BY pq.id \"))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "PqStatistics::TimeToAssign",
-        "method": "pq_data"
-      },
-      "user_input": "bucket_dates.last.strftime(\"%Y-%m-%d\")",
-      "confidence": "Medium",
-      "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "85f1e78f615519e52063c7a5da162e1f24780ece8b0ff3c08ca6a610380ff338",
-      "message": "Possible SQL injection",
-      "file": "lib/rake_task_helpers/db_sanitizer.rb",
-      "line": 24,
-      "link": "http://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "ActiveRecord::Base.connection.execute(\"update #{table} set email='pqsupport+#{abbreviation}' || id || '@digital.justice.gov.uk';\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "RakeTaskHelpers::DBSanitizer",
-        "method": "sanitize_email"
-      },
-      "user_input": "table",
-      "confidence": "Medium",
-      "note": ""
-    },
-    {
-      "warning_type": "Command Injection",
-      "warning_code": 14,
-      "fingerprint": "a0902d954ed2df43aefda77aef187899b596868037ecaa29443510aef88d36e3",
-      "message": "Possible command injection",
-      "file": "lib/pqa/mock_api_server_runner.rb",
-      "line": 20,
-      "link": "http://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "Process.spawn(\"bundle exec rackup -p #{PORT} -P #{PID_FILEPATH} #{RACK_CONFIG_PATH} &> #{LOG_FILEPATH}\", :chdir => (CWD))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "PQA::MockApiServerRunner",
-        "method": "start"
-      },
-      "user_input": "PORT",
-      "confidence": "Medium",
-      "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "d30416b8959cee52d97958d909be7fe870ce17c7d8dc89e708fc3f95bdcdae07",
-      "message": "Possible SQL injection",
-      "file": "lib/pq_statistics/time_to_assign.rb",
-      "line": 43,
-      "link": "http://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "ActiveRecord::Base.connection.execute(((\"SELECT pq.created_at as pq_created_at, \" + \"AND pq.created_at >= '#{bucket_dates.last.strftime(\"%Y-%m-%d\")}'::date \") + \"AND pq.follow_up_to is NULL GROUP BY pq.id \"))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "PqStatistics::TimeToAssign",
-        "method": "pq_data"
-      },
-      "user_input": "bucket_dates.last.strftime(\"%Y-%m-%d\")",
-      "confidence": "Medium",
-      "note": ""
-    },
-    {
       "warning_type": "Remote Code Execution",
       "warning_code": 110,
-      "fingerprint": "d882f63ce96c28fb6c6e0982f2a171460e4b933bfd9b9a5421dca21eef3f76da",
+      "fingerprint": "9ae68e59cfee3e5256c0540dadfeb74e6b72c91997fdb60411063a6e8518144a",
       "check_name": "CookieSerialization",
-      "message": "Use of unsafe cookie serialization strategy `:marshal` might lead to remote code execution",
+      "message": "Use of unsafe cookie serialization strategy `:hybrid` might lead to remote code execution",
       "file": "config/initializers/cookies_serializer.rb",
       "line": 5,
       "link": "https://brakemanscanner.org/docs/warning_types/unsafe_deserialization",
-      "code": "Rails.application.config.action_dispatch.cookies_serializer = :marshal",
+      "code": "Rails.application.config.action_dispatch.cookies_serializer = :hybrid",
       "render_path": null,
       "location": null,
       "user_input": null,
@@ -177,6 +44,6 @@
       "note": ""
     }
   ],
-  "updated": "2023-08-29 16:30:30 +0100",
+  "updated": "2023-11-09 14:02:18 +0000",
   "brakeman_version": "5.4.1"
 }

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -2,4 +2,4 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :marshal
+Rails.application.config.action_dispatch.cookies_serializer = :hybrid


### PR DESCRIPTION
## Description
Change serializer method to `hybrid`. This will allow users to stay logged in and update their cookies in place to use json.
New users logging in will use json to serialize their cookies.

In the future we can move to using the default `json` serializer.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
