### PR TITLE
CDPT-1147:PQ Remove beta1 version from cron jobs

### DIFF
--- a/k8s-deploy/production/early_bird_dispatch_cronjob.yaml
+++ b/k8s-deploy/production/early_bird_dispatch_cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: early-bird-dispatch

--- a/k8s-deploy/production/nightly_import_cronjob.yaml
+++ b/k8s-deploy/production/nightly_import_cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: nightly-import

--- a/k8s-deploy/staging/early_bird_dispatch_cronjob.yaml
+++ b/k8s-deploy/staging/early_bird_dispatch_cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: early-bird-dispatch

--- a/k8s-deploy/staging/nightly_import_cronjob.yaml
+++ b/k8s-deploy/staging/nightly_import_cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: nightly-import

--- a/k8s-deploy/staging/trim_db_cronjob.yaml
+++ b/k8s-deploy/staging/trim_db_cronjob.yaml
@@ -3,7 +3,7 @@
 # database with too many questions which are not progressed or
 # closed and so stagnate in test environments database.
 
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: trim-database


### PR DESCRIPTION
## Description
The Cloud Platform Kubernetes cluster is being updated and support is being dropped for the current CronJob API we use.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
