### PR TITLE
CDPT-526 PQ 9.1 - Change fieldset to div in tabs for ARIA role

### DIFF
--- a/app/views/pqs/show.html.slim
+++ b/app/views/pqs/show.html.slim
@@ -24,7 +24,7 @@
           a#progress-menu-answer href="#progress-menu-answer-data" data-toggle="tab" role="tab" Answer
     #progress-panel.col-md-9
       = form_for @pq, :url => { :action => "update", :id => @pq[:uin] }, :html=>{ :class=>'progress-menu-form' } do |f|
-        fieldset.tab-content role="region" aria-live="polite"
+        fieldset.tab-content role="group" aria-live="polite"
           #progress-menu-pq-data role="tabpanel" class="tab-pane active"
             = render partial:'pq_data', locals: {f: f}
           #progress-menu-fc-data role="tabpanel" class="tab-pane"
@@ -41,3 +41,4 @@
             = render partial:'answer', locals: {f: f}
           .form-group
             = f.submit 'Save', :id => 'save', :class => 'button'
+


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
Changed the fieldset role from 'region' to 'group' as 'region' is not allowed for aria-live type 'polite'.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->
N/A

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/864?assignee=557058%3A2d2f4a33-f427-483f-9c36-338caee60eae&selectedIssue=CDPT-526

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->
N/A

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
Please test the help paths for this application.
