### PR TITLE
CDPT-1232 Don't show rejected Action Officers

### DIFF
--- a/app/models/pq.rb
+++ b/app/models/pq.rb
@@ -87,6 +87,10 @@ class Pq < ApplicationRecord
       where(response: "rejected")
     end
 
+    def not_rejected
+      where.not(response: "rejected")
+    end
+
     def all_rejected?
       all.find { |assignment| !assignment.rejected? }.nil?
     end
@@ -103,6 +107,10 @@ class Pq < ApplicationRecord
 
     def rejected
       where(action_officers_pqs: { response: "rejected" })
+    end
+
+    def not_rejected
+      where.not(action_officers_pqs: { response: "rejected" })
     end
   end
 

--- a/app/views/dashboard/_question_data_commissioned.html.slim
+++ b/app/views/dashboard/_question_data_commissioned.html.slim
@@ -12,10 +12,10 @@
       = question.policy_minister.name
   - if question.action_officer_accepted.nil?
     h3 Action officer(s)
-    - question.action_officers_pqs.each do | ao_pq |
-      - if !ao_pq.rejected? && !ao_pq.action_officer.nil?
-        = link_to ao_pq.action_officer.name, action_officer_path(ao_pq.action_officer)
-        span = ' | '
+    - question.action_officers_pqs.not_rejected.each_with_index do | ao_pq, ind |
+      - if ind > 0
+        = ', '
+      = link_to ao_pq.action_officer.name, action_officer_path(ao_pq.action_officer)
     - question.action_officers_pqs.each do | ao_pq |
       p.space-before
         = render partial: 'shared/ao_reminder_link', locals: {ao_pq: ao_pq, question: question}

--- a/app/views/pqs/_com_data.html.slim
+++ b/app/views/pqs/_com_data.html.slim
@@ -9,8 +9,8 @@ hr/
 .question-allocation
   h3 Action officer(s)
   p
-  - if @pq.action_officers.size > 0
-    - @pq.action_officers_pqs.order(updated_at: :desc).each_with_index do |ao_pq, ind|
+  - if @pq.action_officers.not_rejected.size > 0
+    - @pq.action_officers_pqs.not_rejected.order(updated_at: :desc).each_with_index do |ao_pq, ind|
       - if ind > 0
         = ', '
       = link_to ao_pq.action_officer.name, action_officer_path(ao_pq.action_officer)

--- a/spec/models/pq_spec.rb
+++ b/spec/models/pq_spec.rb
@@ -311,6 +311,12 @@ describe Pq do
         end
       end
 
+      describe "#not_rejected" do
+        it "returns 2 records" do
+          expect(question.action_officers_pqs.not_rejected.count).to eq 2
+        end
+      end
+
       describe "#all_rejected?" do
         it "returns true when all action officers have rejected" do
           accepted.reject(nil, nil)
@@ -340,6 +346,12 @@ describe Pq do
       describe "#rejected" do
         it "returns 2 records" do
           expect(question.action_officers.rejected.count).to eq 2
+        end
+      end
+
+      describe "#not_rejected" do
+        it "returns 2 records" do
+          expect(question.action_officers.not_rejected.count).to eq 2
         end
       end
     end


### PR DESCRIPTION
## Description
Adds a not_rejected method to the action officers association so that only non-rejected action officers are listed against a PQ.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
