### PR TITLE
Don't load 6.1 defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ Bundler.require(*Rails.groups)
 module ParliamentaryQuestions
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.1
+    # config.load_defaults 6.1
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.


### PR DESCRIPTION
## Description
Removing the default because it stops form submissions working.