### PR TITLE
CDPT-1736 Fix internal deadline filter

### DIFF
--- a/app/assets/javascripts/pq.js
+++ b/app/assets/javascripts/pq.js
@@ -184,6 +184,9 @@ var document, $, ga;
           $(li).css('display', 'none');
         }
         var mQuestionDate = moment(questionDate, "DD/MM/YYYY");
+        if (questionDateLocation = ".deadline-date") {
+          mQuestionDate = moment(questionDate, "YYYY-MM-DD");
+        }
         var mFilterDate = moment(filterDate, "DD/MM/YYYY");
         if ( (filter == ".answer-from") || (filter == ".deadline-from") && $(li).css("display") != "none" ) {
           if ( mQuestionDate.isBefore(mFilterDate) ) {

--- a/app/assets/javascripts/pq.js
+++ b/app/assets/javascripts/pq.js
@@ -184,7 +184,7 @@ var document, $, ga;
           $(li).css('display', 'none');
         }
         var mQuestionDate = moment(questionDate, "DD/MM/YYYY");
-        if (questionDateLocation = ".deadline-date") {
+        if (questionDateLocation == ".deadline-date") {
           mQuestionDate = moment(questionDate, "YYYY-MM-DD");
         }
         var mFilterDate = moment(filterDate, "DD/MM/YYYY");

--- a/app/views/dashboard/_dashboard_filter.html.slim
+++ b/app/views/dashboard/_dashboard_filter.html.slim
@@ -24,11 +24,11 @@
           .content
             label for="answer-from" From
             .datepicker.form-group
-              input#answer-from.form-control type="text" placeholder="e.g. 20/06/2014" aria-labelledby="date-for-answer answer-from"
+              input#answer-from.form-control type="text" placeholder="e.g. 20/06/2024" aria-labelledby="date-for-answer answer-from"
               span.fa.fa-calendar title="select a date"
             label for="answer-to" To
             .datepicker.form-group
-              input#answer-to.form-control type="text" placeholder="e.g. 20/06/2014" aria-labelledby="date-for-answer answer-to"
+              input#answer-to.form-control type="text" placeholder="e.g. 20/06/2024" aria-labelledby="date-for-answer answer-to"
               span.fa.fa-calendar title="select a date"
             .clearFilter
               input#clear-answer-filter.right type="button" value="Clear" aria-labelledby="date-for-answer"
@@ -40,12 +40,12 @@
           .content
             label for="deadline-from" From
             .datepicker.form-group
-              input#deadline-from.form-control type="text" placeholder="e.g. 20/06/2014" aria-labelledby="internal-deadline deadline-from"
+              input#deadline-from.form-control type="text" placeholder="e.g. 20/06/2024" aria-labelledby="internal-deadline deadline-from"
               span.fa.fa-calendar title="select a date"
 
             label for="deadline-to" To
             .datepicker.form-group
-              input#deadline-to.form-control type="text" placeholder="e.g. 20/06/2014" aria-labelledby="internal-deadline deadline-to"
+              input#deadline-to.form-control type="text" placeholder="e.g. 20/06/2024" aria-labelledby="internal-deadline deadline-to"
               span.fa.fa-calendar title="select a date"
 
             .clearFilter

--- a/app/views/dashboard/_quick_action_edit_dates.html.slim
+++ b/app/views/dashboard/_quick_action_edit_dates.html.slim
@@ -10,31 +10,31 @@
       label.form-label for="qa_edit_deadline_date"
         'Internal deadline
       .datetimepicker.form-group
-        =text_field_tag 'qa_edit_deadline_date', nil, class: "form-control", type: "text", placeholder: "e.g. 20/06/2014"
+        =text_field_tag 'qa_edit_deadline_date', nil, class: "form-control", type: "text", placeholder: "e.g. 20/06/2024"
         span.fa.fa-calendar title="select a date"
 
       label.form-label for="qa_edit_draft_date"
         'Draft received
       .datetimepicker.form-group
-        =text_field_tag 'qa_edit_draft_date', nil, class: "form-control", type: "text", placeholder: "e.g. 20/06/2014"
+        =text_field_tag 'qa_edit_draft_date', nil, class: "form-control", type: "text", placeholder: "e.g. 20/06/2024"
         span.fa.fa-calendar title="select a date"
 
       label.form-label for="qa_edit_pod_date"
         'POD cleared
       .datetimepicker.form-group
-        =text_field_tag 'qa_edit_pod_date', nil, class: "form-control", type: "text", placeholder: "e.g. 20/06/2014"
+        =text_field_tag 'qa_edit_pod_date', nil, class: "form-control", type: "text", placeholder: "e.g. 20/06/2024"
         span.fa.fa-calendar title="select a date"
 
       label.form-label for="qa_edit_minister_date"
         'Minister cleared
       .datetimepicker.form-group
-        =text_field_tag 'qa_edit_minister_date', nil, class: "form-control", type: "text", placeholder: "e.g. 20/06/2014"
+        =text_field_tag 'qa_edit_minister_date', nil, class: "form-control", type: "text", placeholder: "e.g. 20/06/2024"
         span.fa.fa-calendar title="select a date"
 
       label.form-label for="qa_edit_answered_date"
         'Answered
       .datetimepicker.form-group
-        =text_field_tag 'qa_edit_answered_date', nil, class: "form-control", type: "text", placeholder: "e.g. 20/06/2014"
+        =text_field_tag 'qa_edit_answered_date', nil, class: "form-control", type: "text", placeholder: "e.g. 20/06/2024"
         span.fa.fa-calendar title="select a date"
 
     .button-area

--- a/features/backlog_filter_spec.rb
+++ b/features/backlog_filter_spec.rb
@@ -94,7 +94,6 @@ describe "'Backlog' page filtering:", js: true do
     all_pqs(16, "visible")
   end
 
-
   it "7) by Internal Deadline (From: 20 days ago)." do
     test_date("#internal-deadline", "deadline-from", Time.zone.today - 20)
     test_date("#date-for-answer", "answer-to", Time.zone.today)

--- a/features/backlog_filter_spec.rb
+++ b/features/backlog_filter_spec.rb
@@ -108,8 +108,9 @@ describe "'Backlog' page filtering:", js: true do
   it "8) by Internal Deadline (From: 7 days ago)." do
     test_date("#internal-deadline", "deadline-from", Time.zone.today - 7)
     test_date("#date-for-answer", "answer-to", Time.zone.today)
+    sleep 0.5
     find("h1").click
-    within("#count") { expect(page.text).to eq("6 parliamentary questions out of 16") }
+    within("#count") { expect(page.text).to eq("6 parliamentary questions out of 16.") }
     within(".questions-list") do
       find("li#pq-frame-6").visible?
       find("li#pq-frame-5").visible?
@@ -126,6 +127,7 @@ describe "'Backlog' page filtering:", js: true do
   it "9) by Internal Deadline (From: 20 days time)." do
     test_date("#internal-deadline", "deadline-from", Time.zone.today + 20)
     test_date("#date-for-answer", "answer-to", Time.zone.today + 20)
+    sleep 0.5
     find("h1").click
     within("#count") { expect(page.text).to eq("0 parliamentary questions out of 16.") }
     all_pqs(16, "hidden")
@@ -137,6 +139,7 @@ describe "'Backlog' page filtering:", js: true do
   it "10) by Internal Deadline (To: 20 days ago)." do
     test_date("#internal-deadline", "deadline-from", Time.zone.today + 20)
     test_date("#internal-deadline", "deadline-to", Time.zone.today - 20)
+    sleep 0.5
     find("h1").click
     within("#count") { expect(page.text).to eq("0 parliamentary questions out of 16.") }
     all_pqs(16, "hidden")
@@ -146,8 +149,9 @@ describe "'Backlog' page filtering:", js: true do
   end
 
   it "11) by Internal Deadline (To: 7 days ago)." do
-    test_date("#internal-deadline", "deadline-from", Time.zone.today + 20)
+    test_date("#internal-deadline", "deadline-from", Time.zone.today - 20)
     test_date("#internal-deadline", "deadline-to", Time.zone.today - 7)
+    sleep 0.5
     find("h1").click
     within("#count") { expect(page.text).to eq("11 parliamentary questions out of 16.") }
     within(".questions-list") do
@@ -169,8 +173,9 @@ describe "'Backlog' page filtering:", js: true do
   end
 
   it "12) by Internal Deadline (To: 10 days time)." do
-    test_date("#internal-deadline", "deadline-from", Time.zone.today)
+    test_date("#internal-deadline", "deadline-from", Time.zone.today - 20)
     test_date("#internal-deadline", "deadline-to", Time.zone.today + 10)
+    sleep 0.5
     find("h1").click
     within("#count") { expect(page.text).to eq("16 parliamentary questions out of 16.") }
     all_pqs(16, "visible")

--- a/features/backlog_filter_spec.rb
+++ b/features/backlog_filter_spec.rb
@@ -94,8 +94,8 @@ describe "'Backlog' page filtering:", js: true do
     all_pqs(16, "visible")
   end
 
-  # Disabling internal deadline filter tests as it is broken
-  xit "7) by Internal Deadline (From: 20 days ago)." do
+
+  it "7) by Internal Deadline (From: 20 days ago)." do
     test_date("#internal-deadline", "deadline-from", Time.zone.today - 20)
     test_date("#date-for-answer", "answer-to", Time.zone.today)
     find("h1").click
@@ -106,7 +106,7 @@ describe "'Backlog' page filtering:", js: true do
     all_pqs(16, "visible")
   end
 
-  xit "8) by Internal Deadline (From: 7 days ago)." do
+  it "8) by Internal Deadline (From: 7 days ago)." do
     test_date("#internal-deadline", "deadline-from", Time.zone.today - 7)
     test_date("#date-for-answer", "answer-to", Time.zone.today)
     find("h1").click
@@ -124,7 +124,7 @@ describe "'Backlog' page filtering:", js: true do
     all_pqs(16, "visible")
   end
 
-  xit "9) by Internal Deadline (From: 20 days time)." do
+  it "9) by Internal Deadline (From: 20 days time)." do
     test_date("#internal-deadline", "deadline-from", Time.zone.today + 20)
     test_date("#date-for-answer", "answer-to", Time.zone.today + 20)
     find("h1").click
@@ -135,7 +135,7 @@ describe "'Backlog' page filtering:", js: true do
     all_pqs(16, "visible")
   end
 
-  xit "10) by Internal Deadline (To: 20 days ago)." do
+  it "10) by Internal Deadline (To: 20 days ago)." do
     test_date("#internal-deadline", "deadline-from", Time.zone.today + 20)
     test_date("#internal-deadline", "deadline-to", Time.zone.today - 20)
     find("h1").click
@@ -146,7 +146,7 @@ describe "'Backlog' page filtering:", js: true do
     all_pqs(16, "visible")
   end
 
-  xit "11) by Internal Deadline (To: 7 days ago)." do
+  it "11) by Internal Deadline (To: 7 days ago)." do
     test_date("#internal-deadline", "deadline-from", Time.zone.today + 20)
     test_date("#internal-deadline", "deadline-to", Time.zone.today - 7)
     find("h1").click
@@ -169,7 +169,7 @@ describe "'Backlog' page filtering:", js: true do
     all_pqs(16, "visible")
   end
 
-  xit "12) by Internal Deadline (To: 10 days time)." do
+  it "12) by Internal Deadline (To: 10 days time)." do
     test_date("#internal-deadline", "deadline-from", Time.zone.today)
     test_date("#internal-deadline", "deadline-to", Time.zone.today + 10)
     find("h1").click

--- a/features/in_progress_filters_spec.rb
+++ b/features/in_progress_filters_spec.rb
@@ -88,8 +88,7 @@ describe "'In progress' page filtering:", js: true do
     all_pqs(16, "visible")
   end
 
-  # Disable internal-deadline filter tests as feature is broken
-  xit "7) by Internal Deadline (From: 10 days ago)." do
+  it "7) by Internal Deadline (From: 10 days ago)." do
     test_date("#internal-deadline", "deadline-from", Time.zone.today - 10)
     find("h1").click
     within("#count") { expect(page).to have_text("16 parliamentary questions out of 16.") }
@@ -99,7 +98,7 @@ describe "'In progress' page filtering:", js: true do
     all_pqs(16, "visible")
   end
 
-  xit "8) by Internal Deadline (From: 9 days time)." do
+  it "8) by Internal Deadline (From: 9 days time)." do
     test_date("#internal-deadline", "deadline-from", Time.zone.today + 9)
     find("h1").click
     within("#count") { expect(page).to have_text("6 parliamentary questions out of 16") }
@@ -116,7 +115,7 @@ describe "'In progress' page filtering:", js: true do
     all_pqs(16, "visible")
   end
 
-  xit "9) by Internal Deadline (From: 20 days time)." do
+  it "9) by Internal Deadline (From: 20 days time)." do
     test_date("#internal-deadline", "deadline-from", Time.zone.today + 20)
     find("h1").click
     within("#count") { expect(page).to have_text("0 parliamentary questions out of 16.") }
@@ -126,7 +125,7 @@ describe "'In progress' page filtering:", js: true do
     all_pqs(16, "visible")
   end
 
-  xit "10) by Internal Deadline (To: 10 days ago)." do
+  it "10) by Internal Deadline (To: 10 days ago)." do
     test_date("#internal-deadline", "deadline-to", Time.zone.today - 10)
     find("h1").click
     within("#count") { expect(page).to have_text("0 parliamentary questions out of 16.") }
@@ -136,7 +135,7 @@ describe "'In progress' page filtering:", js: true do
     all_pqs(16, "visible")
   end
 
-  xit "11) by Internal Deadline (To: 9 days time)." do
+  it "11) by Internal Deadline (To: 9 days time)." do
     test_date("#internal-deadline", "deadline-to", Time.zone.today + 9)
     find("h1").click
     within("#count") { expect(page).to have_text("11 parliamentary questions out of 16.") }
@@ -158,7 +157,7 @@ describe "'In progress' page filtering:", js: true do
     all_pqs(16, "visible")
   end
 
-  xit "12) by Internal Deadline (To: 20 days time." do
+  it "12) by Internal Deadline (To: 20 days time." do
     test_date("#internal-deadline", "deadline-to", Time.zone.today + 20)
     find("h1").click
     within("#count") { expect(page).to have_text("16 parliamentary questions out of 16.") }

--- a/features/post_commissioning_spec.rb
+++ b/features/post_commissioning_spec.rb
@@ -37,7 +37,7 @@ describe "After commissioning", js: true do
 
     in_pq_detail(with_pod, "POD check") do
       fillin_date("#pod_clearance")
-      sleep 1
+      sleep 0.5
       find("h1").click
     end
     expect_pq_in_progress_status(with_pod, "POD Cleared")
@@ -46,7 +46,7 @@ describe "After commissioning", js: true do
   it "Parli-branch moves a question to 'With minister' and 'Minister cleared'" do
     in_pq_detail(pod_cleared, "Minister check") do
       fillin_date("#sent_to_answering_minister")
-      sleep 1
+      sleep 0.5
       find("h1").click
     end
     expect_pq_in_progress_status(pod_cleared, "With Minister")
@@ -56,7 +56,7 @@ describe "After commissioning", js: true do
 
     in_pq_detail(pod_cleared, "Minister check") do
       fillin_date("#cleared_by_answering_minister")
-      sleep 1
+      sleep 0.5
       find("h1").click
     end
     expect_pq_in_progress_status(pod_cleared, "Minister Cleared")

--- a/features/qa_pq_edit_dates_spec.rb
+++ b/features/qa_pq_edit_dates_spec.rb
@@ -71,7 +71,7 @@ describe "Testing Quick Action 'Edit PQ dates'", js: true do
       click_on "Edit PQ dates"
       expect(page).to have_text("1 PQ selected")
       fill_in datetype, with: test_date
-      sleep 1
+      sleep 0.5
       find(".notice").click
       click_on "Edit"
     end

--- a/features/transfer_in_pq_spec.rb
+++ b/features/transfer_in_pq_spec.rb
@@ -15,7 +15,7 @@ describe "Transferring IN questions", js: true do
       .select_option
 
     find("#transfer_in_date").set Time.zone.today.strftime("%d/%m/%Y")
-    sleep 1
+    sleep 0.5
     find("h1").click
     click_on "Create PQ"
   end

--- a/features/transfer_out_pq_spec.rb
+++ b/features/transfer_out_pq_spec.rb
@@ -16,7 +16,7 @@ describe "Transferring OUT questions", js: true do
     click_on "PQ commission"
     find("select[name = 'pq[transfer_out_ogd_id]']").find(:xpath, "option[2]").select_option
     find("#transfer_out_date").set(date || Time.zone.today.strftime("%d/%m/%Y"))
-    sleep 1
+    sleep 0.5
     find("h1").click
     click_on "Save"
   end


### PR DESCRIPTION
## Description
The internal deadline filter on the Backlog and In Progress pages is not working.

The reason is that internal_deadline is stored as datetime, whereas date_for_answer is stored as a date. The Javascript that does the filtering was always expecting a date. This has been modified to use the correct format based on the field being filtered on.

---
The date placeholder has also been updated to a more recent date
