### PR TITLE
Update db configmap to match namespace

### DIFF
--- a/k8s-deploy/staging/config_map.yaml
+++ b/k8s-deploy/staging/config_map.yaml
@@ -3,7 +3,7 @@ data:
   ENV: staging
   RAILS_ENV: production
   SENDING_HOST: staging.trackparliamentaryquestions.service.gov.uk
-  DB_NAME: parliamentary_questions_dev
+  DB_NAME: parliamentary_questions_staging
 kind: ConfigMap
 metadata:
   name: environment-variables


### PR DESCRIPTION
## Description
The PQ staging namespace db_name was previously set to parliamentary_questions_dev which didn't make sense for its staging namespace. This was updated (https://github.com/ministryofjustice/cloud-platform-environments/pull/24359/files) which then severed the DB connection. Therefore, was advised by CP to update the config_map to fix the issue.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
