### PR TITLE
CDPT-1958 Enable modsec in non-prod namespaces

### DIFF
--- a/config/kubernetes/development/ingress-live.yaml
+++ b/config/kubernetes/development/ingress-live.yaml
@@ -11,7 +11,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
-      SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=parliamentary-questions-production"
+      SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=parliamentary-questions-development"
 spec:
   ingressClassName: modsec
   rules:

--- a/config/kubernetes/development/ingress-live.yaml
+++ b/config/kubernetes/development/ingress-live.yaml
@@ -8,8 +8,12 @@ metadata:
     nginx.ingress.kubernetes.io/auth-secret: pq-secrets
     external-dns.alpha.kubernetes.io/set-identifier: pq-development-parliamentary-questions-development-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+      SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=parliamentary-questions-production"
 spec:
-  ingressClassName: default
+  ingressClassName: modsec
   rules:
     - host: development.trackparliamentaryquestions.service.gov.uk
       http:
@@ -19,7 +23,7 @@ spec:
           backend:
             service:
               name: parliamentary-questions-service
-              port: 
+              port:
                 number: 3000
   tls:
     - hosts:

--- a/config/kubernetes/staging/ingress-live.yaml
+++ b/config/kubernetes/staging/ingress-live.yaml
@@ -11,7 +11,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
-      SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=parliamentary-questions-production"
+      SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=parliamentary-questions-staging"
 spec:
   ingressClassName: modsec
   rules:

--- a/config/kubernetes/staging/ingress-live.yaml
+++ b/config/kubernetes/staging/ingress-live.yaml
@@ -8,8 +8,12 @@ metadata:
     nginx.ingress.kubernetes.io/auth-secret: pq-secrets
     external-dns.alpha.kubernetes.io/set-identifier: pq-staging-parliamentary-questions-staging-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+      SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=parliamentary-questions-production"
 spec:
-  ingressClassName: default
+  ingressClassName: modsec
   rules:
     - host: staging.trackparliamentaryquestions.service.gov.uk
       http:
@@ -19,7 +23,7 @@ spec:
           backend:
             service:
               name: parliamentary-questions-service
-              port: 
+              port:
                 number: 3000
   tls:
     - hosts:


### PR DESCRIPTION
## Description
[Modsec](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html) will stop malicious traffic going to the service.