### PR TITLE
Don't build if dependabot

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.triggering_actor != 'dependabot[bot]'
 
     outputs:
       build_tag: ${{ steps.vars.outputs.build_tag }}


### PR DESCRIPTION
## Description
PRs created by Dependabot don't have the correct permissions to authenticate to Cloud Platform