### PR TITLE
CDPT-523: Fix tab order sequence.

### DIFF
--- a/app/assets/stylesheets/moj/_pq.scss
+++ b/app/assets/stylesheets/moj/_pq.scss
@@ -736,7 +736,7 @@ textarea.form-control {
   #sidebar {
 
     padding: 0 15px 0 0;
-    min-width: 232px;
+    width: 235px;
 
     input[type="button"]{
       padding-left: 0;

--- a/app/assets/stylesheets/moj/_pq.scss
+++ b/app/assets/stylesheets/moj/_pq.scss
@@ -734,6 +734,10 @@ textarea.form-control {
 
 #dashboard, #preview {
   #sidebar {
+
+    padding: 0 15px 0 0;
+    min-width: 232px;
+
     input[type="button"]{
       padding-left: 0;
       border: none;

--- a/app/assets/stylesheets/moj/_pq.scss
+++ b/app/assets/stylesheets/moj/_pq.scss
@@ -49,6 +49,11 @@ label {
   position: relative;
 }
 
+.govuk-grid-row {
+  margin-left: 0;
+  margin-right: 0;
+}
+
 //==============================================================================
 // = GLOBAL CLASSES ============================================================
 //==============================================================================
@@ -850,13 +855,6 @@ textarea.form-control {
           #keywords { width: 100%; }
           .clearFilter { overflow: hidden; }
         }
-      }
-    }
-  }
-  @media (max-width: 991px) {
-    #sidebar {
-      #filters, #quick-links {
-        width: 235px;
       }
     }
   }

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -5,5 +5,5 @@
     h1.govuk-heading-l Parliamentary questions - In progress
   - if @dashboard_state == "Backlog"
     h1.govuk-heading-l Parliamentary questions - Backlog
-  = render partial: "dashboard/questions_list", locals: {questions: @questions, action_officers: @action_officers }
   = render partial: "dashboard_filter"
+  = render partial: "dashboard/questions_list", locals: {questions: @questions, action_officers: @action_officers }

--- a/app/views/early_bird_dashboard/index.html.slim
+++ b/app/views/early_bird_dashboard/index.html.slim
@@ -4,7 +4,7 @@
     h1.govuk-heading-l New parliamentary questions to be allocated today (#{@now})
     = render partial: 'shared/flash_messages'
 
-    #sidebar.col-md-3.col-md-push-9
+    #sidebar.govuk-grid-column-one-quarter
       #filters.js-stick-at-top-when-scrolling
         h2.govuk-heading-m Filter
         #question-type.filter-box
@@ -36,7 +36,7 @@
 
         a target="_blank" href="#{@parliament_url}" Today's PQs for all departments (opens in a new tab)
 
-    .col-md-9.col-md-pull-3
+    .govuk-grid-column-three-quarters
       #count
         strong #{@questions.length}
         = ' '


### PR DESCRIPTION
## Description
Following an accessibility audit recommending swapping the position of the filter and question list elements on the pags.  This would fix a tab order issue.

### Screenshots
![pq-reversed-filter-position](https://github.com/user-attachments/assets/e5747f6b-c11f-42e9-9780-e130ae0be753)

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPT-523

### Deployment
This branch is part of the "PQ: Implement new design system" work and thus should only be merged to that branch until all tickets are completed.

### Manual testing instructions
See the Jira ticket re: the expected tab order.