### PR TITLE
Format date consistently

### DIFF
--- a/app/views/dashboard/_question_data_commissioned.html.slim
+++ b/app/views/dashboard/_question_data_commissioned.html.slim
@@ -1,7 +1,7 @@
 - if question.internal_deadline
   h3.govuk-heading-s Internal deadline:
   p.govuk-body.deadline-date.text
-    = question.internal_deadline.to_formatted_s(:db)
+    = question.internal_deadline.to_formatted_s(:no_seconds)
     = render partial: 'shared/deadline_time', locals: {internal_deadline: question.internal_deadline, is_closed: question.closed?, draft_reply: question.draft_answer_received}
   h3.govuk-heading-s Replying minister:
   p.govuk-body.replying-minister

--- a/app/views/dashboard/_question_data_commissioned.html.slim
+++ b/app/views/dashboard/_question_data_commissioned.html.slim
@@ -1,7 +1,7 @@
 - if question.internal_deadline
   h3.govuk-heading-s Internal deadline:
   p.govuk-body.deadline-date.text
-    = question.internal_deadline.to_fs
+    = question.internal_deadline.to_formatted_s(:db)
     = render partial: 'shared/deadline_time', locals: {internal_deadline: question.internal_deadline, is_closed: question.closed?, draft_reply: question.draft_answer_received}
   h3.govuk-heading-s Replying minister:
   p.govuk-body.replying-minister

--- a/app/views/dashboard/_question_data_commissioned.html.slim
+++ b/app/views/dashboard/_question_data_commissioned.html.slim
@@ -1,7 +1,7 @@
 - if question.internal_deadline
   h3.govuk-heading-s Internal deadline:
   p.govuk-body.deadline-date.text
-    = question.internal_deadline
+    = question.internal_deadline.to_fs
     = render partial: 'shared/deadline_time', locals: {internal_deadline: question.internal_deadline, is_closed: question.closed?, draft_reply: question.draft_answer_received}
   h3.govuk-heading-s Replying minister:
   p.govuk-body.replying-minister

--- a/app/views/dashboard/_question_data_uncommissioned.html.slim
+++ b/app/views/dashboard/_question_data_uncommissioned.html.slim
@@ -26,7 +26,7 @@
 
       label.form-label for="pq_internal_deadline-#{question.id}" Internal deadline
       .datetimepicker.form-group.default-time#internal-deadline
-        input.deadline-date.form-control.required-for-commission id="pq_internal_deadline-#{question.id}" name="commission_form[internal_deadline]" type="text" value=(question.internal_deadline.to_s)
+        input.deadline-date.form-control.required-for-commission id="pq_internal_deadline-#{question.id}" name="commission_form[internal_deadline]" type="text" value=(question.internal_deadline&.to_fs)
         span.fa.fa-calendar title="select a date"
       = render partial: 'shared/deadline_time', locals: {internal_deadline: question.internal_deadline, is_closed: question.closed?, draft_reply: question.draft_answer_received}
     .govuk-grid-column-full.form-group

--- a/app/views/pqs/_answer.html.slim
+++ b/app/views/pqs/_answer.html.slim
@@ -2,7 +2,7 @@ h2.govuk-heading-m Answer
 .form-group
   label.form-label for="answer_submitted"  Date answer submitted
   .datetimepicker
-    input#answer_submitted.form-control name="pq[answer_submitted]" type="text" value=(@pq.answer_submitted.to_s) /
+    input#answer_submitted.form-control name="pq[answer_submitted]" type="text" value=(@pq.answer_submitted&.to_fs) /
     span.fa.fa-calendar title="select a date"
 - if @pq.answer_submitted.present? && @pq.date_for_answer.present?
   - @answer_target = @pq.date_for_answer + 18.hours

--- a/app/views/pqs/_com_data.html.slim
+++ b/app/views/pqs/_com_data.html.slim
@@ -3,7 +3,7 @@ h2.govuk-heading-m PQ commission
   label.form-label for="pq_internal_deadline"
     | Internal deadline#{render partial: 'shared/deadline_time', locals: {internal_deadline: @pq.internal_deadline, is_closed: @pq.closed?, draft_reply: @pq.draft_answer_received }}
   .datetimepicker.default-time
-    input#pq_internal_deadline.form-control name="pq[internal_deadline]" type="text" value=(@pq.internal_deadline.to_s) /
+    input#pq_internal_deadline.form-control name="pq[internal_deadline]" type="text" value=(@pq.internal_deadline&.to_fs) /
     span.fa.fa-calendar title="select a date"
 hr/
 .question-allocation
@@ -59,5 +59,5 @@ hr/
 .form-group
   label.form-label for="transfer_out_date"  Date transferred out
   .datetimepicker
-    input#transfer_out_date.form-control name="pq[transfer_out_date]" type="text" value=(@pq.transfer_out_date.to_s) /
+    input#transfer_out_date.form-control name="pq[transfer_out_date]" type="text" value=(@pq.transfer_out_date&.to_fs) /
     span.fa.fa-calendar title="select a date"

--- a/app/views/pqs/_minister_check.html.slim
+++ b/app/views/pqs/_minister_check.html.slim
@@ -3,12 +3,12 @@ h2.govuk-heading-m Minister check
   .form-group
     label.form-label for="sent_to_answering_minister"  Date sent to answering minister
     .datetimepicker
-      input#sent_to_answering_minister.form-control name="pq[sent_to_answering_minister]" type="text" value=(@pq.sent_to_answering_minister.to_s) /
+      input#sent_to_answering_minister.form-control name="pq[sent_to_answering_minister]" type="text" value=(@pq.sent_to_answering_minister&.to_fs) /
       span.fa.fa-calendar title="select a date"
   .form-group
     label.form-label for="cleared_by_answering_minister"  Date cleared by answering minister
     .datetimepicker
-      input#cleared_by_answering_minister.form-control name="pq[cleared_by_answering_minister]" type="text" value=(@pq.cleared_by_answering_minister.to_s) /
+      input#cleared_by_answering_minister.form-control name="pq[cleared_by_answering_minister]" type="text" value=(@pq.cleared_by_answering_minister&.to_fs) /
       span.fa.fa-calendar title="select a date"
 - if @pq.policy_minister_id
   hr/
@@ -16,10 +16,10 @@ h2.govuk-heading-m Minister check
     .form-group
       label.form-label for="sent_to_policy_minister"  Date sent to policy minister
       .datetimepicker
-        input#sent_to_policy_minister.form-control name="pq[sent_to_policy_minister]" type="text" value=(@pq.sent_to_policy_minister.to_s) /
+        input#sent_to_policy_minister.form-control name="pq[sent_to_policy_minister]" type="text" value=(@pq.sent_to_policy_minister&.to_fs) /
         span.fa.fa-calendar title="select a date"
     .form-group
       label.form-label for="cleared_by_policy_minister"  Date cleared by policy minister
       .datetimepicker
-        input#cleared_by_policy_minister.form-control name="pq[cleared_by_policy_minister]" type="text" value=(@pq.cleared_by_policy_minister.to_s) /
+        input#cleared_by_policy_minister.form-control name="pq[cleared_by_policy_minister]" type="text" value=(@pq.cleared_by_policy_minister&.to_fs) /
         span.fa.fa-calendar title="select a date"

--- a/app/views/pqs/_pod_check.html.slim
+++ b/app/views/pqs/_pod_check.html.slim
@@ -15,5 +15,5 @@ br
     ' Date cleared by
     abbr title="Private Office Directorate" POD
   .datetimepicker
-    input#pod_clearance.form-control name="pq[pod_clearance]" type="text" value=(@pq.pod_clearance.to_s) /
+    input#pod_clearance.form-control name="pq[pod_clearance]" type="text" value=(@pq.pod_clearance&.to_fs) /
     span.fa.fa-calendar title="select a date"

--- a/app/views/pqs/_pq_draft.html.slim
+++ b/app/views/pqs/_pq_draft.html.slim
@@ -3,9 +3,9 @@ h2.govuk-heading-m PQ draft
   - @pq.action_officers_pqs.each do |ao_pq|
     - if ao_pq.accepted?
       h3.govuk-heading-s Date PQ accepted by action officer
-      p.govuk-body= ao_pq.updated_at.to_s
+      p.govuk-body= ao_pq.updated_at&.to_fs
 .form-group
   label.form-label for="draft_answer_received"  Date PQ returned by action officer
   .datetimepicker
-    input#draft_answer_received.form-control name="pq[draft_answer_received]" type="text" value=(@pq.draft_answer_received.to_s) /
+    input#draft_answer_received.form-control name="pq[draft_answer_received]" type="text" value=(@pq.draft_answer_received&.to_fs) /
     span.fa.fa-calendar title="select a date"

--- a/app/views/shared/_rejected_reasons.html.slim
+++ b/app/views/shared/_rejected_reasons.html.slim
@@ -4,7 +4,7 @@ ul
       li
         p.govuk-body.pq-msg-warning
           = link_to r.action_officer.name, action_officer_path(r.action_officer)
-          |  rejected at: #{r.updated_at.to_s}
+          |  rejected at: #{r.updated_at&.to_fs}
           br/
           = r.reason_option
           | : #{r.reason}

--- a/app/views/transferred/_form.html.slim
+++ b/app/views/transferred/_form.html.slim
@@ -15,7 +15,7 @@
       .form-group
         label.form-label for="pq_dateforanswer"  Date for answer (required)
         .datetimepicker
-          input#pq_dateforanswer.form-control.pq_dateforanswer name="pq[date_for_answer]" type="text" value=(@pq.date_for_answer.to_s) /
+          input#pq_dateforanswer.form-control.pq_dateforanswer name="pq[date_for_answer]" type="text" value=(@pq.date_for_answer&.to_fs) /
           span.fa.fa-calendar title="select a date"
       p.govuk-body House
       .form-group.inline aria-label="selection for house type"
@@ -53,7 +53,7 @@
       .form-group
         label.form-label for="transfer_in_date"  Date transferred in (required)
         .datetimepicker
-          input#transfer_in_date.form-control name="pq[transfer_in_date]" type="text" value=(@pq.transfer_in_date.to_s) /
+          input#transfer_in_date.form-control name="pq[transfer_in_date]" type="text" value=(@pq.transfer_in_date&.to_fs) /
           span.fa.fa-calendar title="select a date"
       .form-group
         = f.submit 'Create PQ', :class => 'button'

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,5 +1,6 @@
 Time::DATE_FORMATS[:default] = "%d/%m/%Y %H:%M"
 Time::DATE_FORMATS[:wordy] = "on <strong>%d/%m/%Y</strong> at <strong>%H:%M</strong>"
-Time::DATE_FORMATS[:db] = "%Y-%m-%d %H:%M"
+Time::DATE_FORMATS[:db] = "%Y-%m-%d %H:%M:%S"
+Time::DATE_FORMATS[:no_seconds] = "%Y-%m-%d %H:%M"
 Time::DATE_FORMATS[:export] = "%Y-%m-%d %H:%M"
 Time::DATE_FORMATS[:date] = "%d/%m/%Y"

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,5 +1,5 @@
 Time::DATE_FORMATS[:default] = "%d/%m/%Y %H:%M"
 Time::DATE_FORMATS[:wordy] = "on <strong>%d/%m/%Y</strong> at <strong>%H:%M</strong>"
-Time::DATE_FORMATS[:db] = "%Y-%m-%d %H:%M:%S"
+Time::DATE_FORMATS[:db] = "%Y-%m-%d %H:%M"
 Time::DATE_FORMATS[:export] = "%Y-%m-%d %H:%M"
 Time::DATE_FORMATS[:date] = "%d/%m/%Y"

--- a/spec/features/qa_pq_edit_dates_spec.rb
+++ b/spec/features/qa_pq_edit_dates_spec.rb
@@ -4,6 +4,7 @@ describe "Testing Quick Action 'Edit PQ dates'", :js do
   let(:ao) { ActionOfficer.find_by(email: "ao1@pq.com") }
   let(:minister) { Minister.first }
   let(:test_date) { "#{Time.zone.today + 3} 12:00" }
+  let(:formatted_test_date) { (Time.zone.today + 3.days + 12.hours).to_fs }
   let!(:pq_first) { FactoryBot.create :draft_pending_pq }
   let!(:pq_second) { FactoryBot.create :draft_pending_pq }
   let!(:pq_third) { FactoryBot.create :draft_pending_pq }
@@ -87,7 +88,7 @@ describe "Testing Quick Action 'Edit PQ dates'", :js do
     click_link "In progress"
     within("#pq-frame-#{pq_third.id}") { click_link(pq_third.uin.to_s) }
     click_link(tablink)
-    expect(page).to have_field("pq[#{datefield}]", with: "#{test_date}:00 UTC")
+    expect(page).to have_field("pq[#{datefield}]", with: formatted_test_date)
     click_link "In progress"
   end
 end


### PR DESCRIPTION
## Description
Ensure all timestamps in forms are formatted as `dd/mm/yyyy hh:mm`
