### PR TITLE
CDPT-1032 Fix pq details page focus order

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 <a id="readme-top"></a>
 
-<br>
-
 <img alt="MoJ logo" src="https://moj-logos.s3.eu-west-2.amazonaws.com/moj-uk-logo.png" width="200">
 
 # Parliamentary Questions
@@ -40,6 +38,7 @@ $ cd parliamentary-questions
 #### Latest Version of Ruby
 
 If you don't have `rbenv` already installed, install it as follows:
+
 ```
 $ brew install rbenv ruby-build
 $ rbenv init
@@ -80,21 +79,23 @@ $ yarn install
 
 Mock data can be automatically imported by running the following rake task (it will make use of a mock API server running on localhost:8888 so make sure this port is free):
 
-'''
+```
 $ PQ_REST_API_HOST=http://localhost:8888 bundle exec rake pqa:import_dummy_data
 ```
 
 Finally, a rake task is also provided to load PQ&A XML data into the system.
 
 ```
-$ bundle exec rake pqa:import_from_xml[path/to/question_file.xml]
+$ bundle exec rake pqa:import_from_xml[question_file.xml]
 ```
 
 #### Running locally:
 
 Use the dev command to run the application. This will use Foreman to start the rails server as well as compiling the css and js. Any changes to the css and js will be live updated.
 
+```
 $ bin/dev
+```
 
 The site will be accessible at http://localhost:3000.
 
@@ -102,8 +103,8 @@ The site will be accessible at http://localhost:3000.
 
 In order to run the tests, you can use:
 
-```sh
-bundle exec rake
+```
+$ bundle exec rake
 ```
 
 This will run specs and rubocop linting. Or you can run them individually, with `rake rubocop` and `rake spec`.
@@ -115,23 +116,27 @@ It's done using devise and devise invitable:
 * https://github.com/plataformatec/devise
 * https://github.com/scambra/devise_invitable
 
-For development you can create users with a rake task.
+For development, you can create users with a rake task.
 
-```
 # default user
-rake user:create
+```
+$ rake user:create
+```
 
 # admin user
-rake user:create_admin
+```
+$ rake user:create_admin
+```
 
 # specific email, password, name
-rake "user:create_admin[admin@admin.com, 123456789, admin]"
+```
+$ rake "user:create_admin[admin@admin.com, 123456789, admin]"
 ```
 
 ## Emails
 Emails are sent using the [GOVUK Notify service](https://www.notifications.service.gov.uk).
 
-Please refer to the [readme](https://github.com/ministryofjustice/parliamentary-questions/tree/dev/app/mailers)in the mailers folder
+Please refer to the [readme](https://github.com/ministryofjustice/parliamentary-questions/tree/dev/app/mailers) in the mailers folder
 for details of how to get an account and obtain an API key.
 
 ## Exceptions
@@ -140,7 +145,7 @@ Any exceptions raised in any deployed environment will be sent to [Sentry](https
 
 ## Environment Variables
 
-This is an up to date list of the environment variables used by the app.
+This is an up-to-date list of the environment variables used by the app.
 Refer to the provisioning code for the actual values expected to be set on each
 specific environment.
 
@@ -150,24 +155,26 @@ by the [mock implementation](https://github.com/ministryofjustice/parliamentary-
 of Parliament's Question and Answer API. `TEST_USER_PASS` can be set to any value. `DEVISE_SENDER` can be set to `no-reply@digital.justice.gov.uk`.
 Instructions on setting up the `GOVUK_NOTIFY_API_KEY` can be found in the [mailer readme](https://github.com/ministryofjustice/parliamentary-questions/tree/dev/app/mailers).
 
-Variable Name          |Required for local development  | Description
------------------------| ------------------------------ | -----------------------------
-`PQ_REST_API_HOST`     | y                              | Hostname of the Parlamentary Question and Answers API
-`PQ_REST_API_USERNAME` | n                              | Username
-`PQ_REST_API_PASSWORD` | n                              | Password
-`DEVISE_SECRET`        | n                              | Secret Devise Token
-`DEVISE_SENDER`        | y                              | Email address used for signup/signin/password related notifications
-`SENDING_HOST`         | n                              | Host for URLs in emails
-`CA_CERT`              | n                              | Absolute Path of the system's SSL certificates dir (e.g. `/etc/ssl/certs`)
-`ASSET_HOST`           | n                              | Host where Rails' assets pipeline will deploy the assets
-`TEST_USER`            | n                              | The current application version tag
-`TEST_USER_PASS`       | y                              | The password for the test users created by `rake db:staging:sync` and smoke tests
-`GOVUK_NOTIFY_API_KEY` | y                              | A key required to send emails via [GovUK Notify](https://www.notifications.service.gov.uk/)
+| Variable Name          |Required for local development  | Description |
+|------------------------| ------------------------------ | -----------------------------|
+| `PQ_REST_API_HOST`     | y                              | Hostname of the Parlamentary Question and Answers API |
+| `PQ_REST_API_USERNAME` | n                              | Username |
+| `PQ_REST_API_PASSWORD` | n                              | Password |
+| `DEVISE_SECRET`        | n                              | Secret Devise Token |
+| `DEVISE_SENDER`        | y                              | Email address used for signup/signin/password related notifications |
+| `SENDING_HOST`         | n                              | Host for URLs in emails |
+| `CA_CERT`              | n                              | Absolute Path of the system's SSL certificates dir (e.g. `/etc/ssl/certs`) |
+| `ASSET_HOST`           | n                              | Host where Rails' assets pipeline will deploy the assets |
+| `TEST_USER`            | n                              | The current application version tag |
+| `TEST_USER_PASS`       | y                              | The password for the test users created by `rake db:staging:sync` and smoke tests |
+| `GOVUK_NOTIFY_API_KEY` | y                              | A key required to send emails via [GovUK Notify](https://www.notifications.service.gov.uk/) |
 
 You can add the env variables required for local development to your `bash_profile` using the format:
+
 ```
 export [NAME_OF_VARIABLE]=[VALUE-OF-VARIABLE]
 ```
+
 for example:
 ```
 export GOVUK_NOTIFY_API_KEY=a-super-great-key

--- a/app/assets/stylesheets/moj/_pq.scss
+++ b/app/assets/stylesheets/moj/_pq.scss
@@ -365,6 +365,12 @@ textarea.form-control {
   margin: .5em 0;
 }
 
+#pq-details #save-button {
+  border: 0;
+  margin-bottom: 0;
+  padding: 30px 20px;
+}
+
 .questions-list {
   padding: 0 0 20px;
   > li {

--- a/app/assets/stylesheets/moj/_pq.scss
+++ b/app/assets/stylesheets/moj/_pq.scss
@@ -647,6 +647,21 @@ textarea.form-control {
   #pq-detail-area {
     margin-top: 15px;
 
+    .govuk-tabs__panel{
+      border-bottom: none;
+    }
+
+    @media (min-width: 641px) {
+      #save-button {
+        border-top: 0;
+        border-right: 1px;
+        border-bottom: 1px;
+        border-left: 1px;
+        border-style: solid;
+        border-color: #b1b4b6;
+      }
+    }
+
     nav {
       z-index: 1;
       padding: 0;

--- a/app/views/pqs/_answer.html.slim
+++ b/app/views/pqs/_answer.html.slim
@@ -1,4 +1,3 @@
-h2.govuk-heading-m Answer
 .form-group
   label.form-label for="answer_submitted"  Date answer submitted
   .datetimepicker

--- a/app/views/pqs/_com_data.html.slim
+++ b/app/views/pqs/_com_data.html.slim
@@ -1,4 +1,3 @@
-h2.govuk-heading-m PQ commission
 .form-group
   label.form-label for="pq_internal_deadline"
     | Internal deadline#{render partial: 'shared/deadline_time', locals: {internal_deadline: @pq.internal_deadline, is_closed: @pq.closed?, draft_reply: @pq.draft_answer_received }}

--- a/app/views/pqs/_minister_check.html.slim
+++ b/app/views/pqs/_minister_check.html.slim
@@ -1,4 +1,3 @@
-h2.govuk-heading-m Minister check
 #answeringminister
   .form-group
     label.form-label for="sent_to_answering_minister"  Date sent to answering minister

--- a/app/views/pqs/_pod_check.html.slim
+++ b/app/views/pqs/_pod_check.html.slim
@@ -1,6 +1,3 @@
-h2.govuk-heading-m
-  abbr title="Private Office Directorate" POD
-  'check
 h3.govuk-heading-s
   ' Date sent to
   abbr title="Private Office Directorate" POD

--- a/app/views/pqs/_pq_data.html.slim
+++ b/app/views/pqs/_pq_data.html.slim
@@ -1,4 +1,3 @@
-h2.govuk-heading-m PQ Details
 h3.govuk-heading-s
   abbr title="Unique Identification Number" UIN
 p.govuk-body= @pq.uin

--- a/app/views/pqs/_pq_draft.html.slim
+++ b/app/views/pqs/_pq_draft.html.slim
@@ -1,4 +1,3 @@
-h2.govuk-heading-m PQ draft
 - if @pq.action_officers.size > 0
   - @pq.action_officers_pqs.each do |ao_pq|
     - if ao_pq.accepted?

--- a/app/views/pqs/show.html.slim
+++ b/app/views/pqs/show.html.slim
@@ -3,37 +3,57 @@
   = render partial: 'shared/errors', object: @pq
   = render 'pq_header'
   #pq-detail-area
-    nav.col-md-3
-      p.govuk-body.govuk-visually-hidden Jump to a section...
-      ul.nav.nav-stacked data-tabs="tabs" role="tablist"
-        li.active
-          a#progress-menu-pq href="#progress-menu-pq-data" data-toggle="tab" role="tab" PQ Details
-        li
-          a#progress-menu-com href="#progress-menu-com-data" data-toggle="tab" role="tab" PQ commission
-        li
-          a#progress-menu-sub href="#progress-menu-sub-data" data-toggle="tab" role="tab" PQ draft
-        li
-          a#progress-menu-pod href="#progress-menu-pod-data" data-toggle="tab" role="tab"
+    .govuk-tabs[data-module="govuk-tabs"]
+      h2.govuk-tabs__title
+        |  Contents
+      ul.govuk-tabs__list
+        li.govuk-tabs__list-item.govuk-tabs__list-item--selected
+          a.govuk-tabs__tab[href="#details"]
+            | Details
+        li.govuk-tabs__list-item
+          a.govuk-tabs__tab[href="#commissioning"]
+            | Commission
+        li.govuk-tabs__list-item
+          a.govuk-tabs__tab[href="#draft"]
+            | Draft
+        li.govuk-tabs__list-item
+          a.govuk-tabs__tab[href="#pod-check"]
+            |
             abbr title="Private Office Directorate" POD
-            span  check
-        li
-          a#progress-menu-min href="#progress-menu-min-data" data-toggle="tab" role="tab" Minister check
-        li
-          a#progress-menu-answer href="#progress-menu-answer-data" data-toggle="tab" role="tab" Answer
-    #progress-panel.col-md-9
+            '  check
+        li.govuk-tabs__list-item
+          a.govuk-tabs__tab[href="#minister-check"]
+            | Minister check
+        li.govuk-tabs__list-item
+          a.govuk-tabs__tab[href="#answer"]
+            | Answer
       = form_for @pq, :url => { :action => "update", :id => @pq[:uin] }, :html=>{ :class=>'progress-menu-form' } do |f|
         fieldset.tab-content role="group" aria-live="polite"
-          #progress-menu-pq-data role="tabpanel" class="tab-pane active"
+          #details.govuk-tabs__panel
+            h2.govuk-heading-l
+              | Details
             = render partial:'pq_data', locals: {f: f}
-          #progress-menu-com-data role="tabpanel" class="tab-pane"
+          #commissioning.govuk-tabs__panel.govuk-tabs__panel--hidden
+            h2.govuk-heading-l
+              | Commission
             = render  partial:'com_data', locals: {f: f, action_officers: @action_officers}
-          #progress-menu-sub-data role="tabpanel" class="tab-pane"
+          #draft.govuk-tabs__panel.govuk-tabs__panel--hidden
+            h2.govuk-heading-l
+              | Draft
             = render  partial:'pq_draft', locals: {f: f}
-          #progress-menu-pod-data role="tabpanel" class="tab-pane"
+          #pod-check.govuk-tabs__panel.govuk-tabs__panel--hidden
+            h2.govuk-heading-l
+              |
+              abbr title="Private Office Directorate" POD
+              '  check
             = render partial:'pod_check', locals: {f: f}
-          #progress-menu-min-data role="tabpanel" class="tab-pane"
+          #minister-check.govuk-tabs__panel.govuk-tabs__panel--hidden
+            h2.govuk-heading-l
+              | Minister check
             = render partial:'minister_check', locals: {f: f}
-          #progress-menu-answer-data role="tabpanel" class="tab-pane"
+          #answer.govuk-tabs__panel.govuk-tabs__panel--hidden
+            h2.govuk-heading-l
+              | Answer
             = render partial:'answer', locals: {f: f}
-          .form-group
+          #save-button
             = f.submit 'Save', :id => 'save', :class => 'button'


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
The vertical tab style in the details page is replaced with the GDS Design System horizontal tab component.  This fixes the tab order issue described in the accessibility review (Section 9.3).

### Screenshots
<!-- Screenshots of the new changes if appropriate -->
Before:

![pq-details-tabs-before](https://github.com/user-attachments/assets/598f7d05-cd11-4d77-9df9-eb764b566366)

After

![pq-details-tabs-after](https://github.com/user-attachments/assets/a2ae7fde-af2c-4f3d-864d-75a7ff906c3b)

### Related JIRA tickets
https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/864?selectedIssue=CDPT-1032
