### PR TITLE
CDPT-1032 Fix PQ Details page focus order.

### DIFF
--- a/app/assets/stylesheets/moj/_pq.scss
+++ b/app/assets/stylesheets/moj/_pq.scss
@@ -365,6 +365,12 @@ textarea.form-control {
   margin: .5em 0;
 }
 
+#pq-details #save-button {
+  border: 0;
+  margin-bottom: 0;
+  padding: 30px 20px;
+}
+
 .questions-list {
   padding: 0 0 20px;
   > li {

--- a/app/assets/stylesheets/moj/_pq.scss
+++ b/app/assets/stylesheets/moj/_pq.scss
@@ -647,6 +647,21 @@ textarea.form-control {
   #pq-detail-area {
     margin-top: 15px;
 
+    .govuk-tabs__panel{
+      border-bottom: none;
+    }
+
+    @media (min-width: 641px) {
+      #save-button {
+        border-top: 0;
+        border-right: 1px;
+        border-bottom: 1px;
+        border-left: 1px;
+        border-style: solid;
+        border-color: #b1b4b6;
+      }
+    }
+
     nav {
       z-index: 1;
       padding: 0;

--- a/app/views/pqs/_answer.html.slim
+++ b/app/views/pqs/_answer.html.slim
@@ -1,4 +1,3 @@
-h2.govuk-heading-m Answer
 .form-group
   label.form-label for="answer_submitted"  Date answer submitted
   .datetimepicker

--- a/app/views/pqs/_com_data.html.slim
+++ b/app/views/pqs/_com_data.html.slim
@@ -1,4 +1,3 @@
-h2.govuk-heading-m PQ commission
 .form-group
   label.form-label for="pq_internal_deadline"
     | Internal deadline#{render partial: 'shared/deadline_time', locals: {internal_deadline: @pq.internal_deadline, is_closed: @pq.closed?, draft_reply: @pq.draft_answer_received }}

--- a/app/views/pqs/_minister_check.html.slim
+++ b/app/views/pqs/_minister_check.html.slim
@@ -1,4 +1,3 @@
-h2.govuk-heading-m Minister check
 #answeringminister
   .form-group
     label.form-label for="sent_to_answering_minister"  Date sent to answering minister

--- a/app/views/pqs/_pod_check.html.slim
+++ b/app/views/pqs/_pod_check.html.slim
@@ -1,6 +1,3 @@
-h2.govuk-heading-m
-  abbr title="Private Office Directorate" POD
-  'check
 h3.govuk-heading-s
   ' Date sent to
   abbr title="Private Office Directorate" POD

--- a/app/views/pqs/_pq_data.html.slim
+++ b/app/views/pqs/_pq_data.html.slim
@@ -1,4 +1,3 @@
-h2.govuk-heading-m PQ Details
 h3.govuk-heading-s
   abbr title="Unique Identification Number" UIN
 p.govuk-body= @pq.uin

--- a/app/views/pqs/_pq_draft.html.slim
+++ b/app/views/pqs/_pq_draft.html.slim
@@ -1,4 +1,3 @@
-h2.govuk-heading-m PQ draft
 - if @pq.action_officers.size > 0
   - @pq.action_officers_pqs.each do |ao_pq|
     - if ao_pq.accepted?

--- a/app/views/pqs/show.html.slim
+++ b/app/views/pqs/show.html.slim
@@ -3,37 +3,57 @@
   = render partial: 'shared/errors', object: @pq
   = render 'pq_header'
   #pq-detail-area
-    nav.col-md-3
-      p.govuk-body.govuk-visually-hidden Jump to a section...
-      ul.nav.nav-stacked data-tabs="tabs" role="tablist"
-        li.active
-          a#progress-menu-pq href="#progress-menu-pq-data" data-toggle="tab" role="tab" PQ Details
-        li
-          a#progress-menu-com href="#progress-menu-com-data" data-toggle="tab" role="tab" PQ commission
-        li
-          a#progress-menu-sub href="#progress-menu-sub-data" data-toggle="tab" role="tab" PQ draft
-        li
-          a#progress-menu-pod href="#progress-menu-pod-data" data-toggle="tab" role="tab"
+    .govuk-tabs[data-module="govuk-tabs"]
+      h2.govuk-tabs__title
+        |  Contents
+      ul.govuk-tabs__list
+        li.govuk-tabs__list-item.govuk-tabs__list-item--selected
+          a.govuk-tabs__tab[href="#details"]
+            | Details
+        li.govuk-tabs__list-item
+          a.govuk-tabs__tab[href="#commissioning"]
+            | Commission
+        li.govuk-tabs__list-item
+          a.govuk-tabs__tab[href="#draft"]
+            | Draft
+        li.govuk-tabs__list-item
+          a.govuk-tabs__tab[href="#pod-check"]
+            |
             abbr title="Private Office Directorate" POD
-            span  check
-        li
-          a#progress-menu-min href="#progress-menu-min-data" data-toggle="tab" role="tab" Minister check
-        li
-          a#progress-menu-answer href="#progress-menu-answer-data" data-toggle="tab" role="tab" Answer
-    #progress-panel.col-md-9
+            '  check
+        li.govuk-tabs__list-item
+          a.govuk-tabs__tab[href="#minister-check"]
+            | Minister check
+        li.govuk-tabs__list-item
+          a.govuk-tabs__tab[href="#answer"]
+            | Answer
       = form_for @pq, :url => { :action => "update", :id => @pq[:uin] }, :html=>{ :class=>'progress-menu-form' } do |f|
         fieldset.tab-content role="group" aria-live="polite"
-          #progress-menu-pq-data role="tabpanel" class="tab-pane active"
+          #details.govuk-tabs__panel
+            h2.govuk-heading-l
+              | Details
             = render partial:'pq_data', locals: {f: f}
-          #progress-menu-com-data role="tabpanel" class="tab-pane"
+          #commissioning.govuk-tabs__panel.govuk-tabs__panel--hidden
+            h2.govuk-heading-l
+              | Commission
             = render  partial:'com_data', locals: {f: f, action_officers: @action_officers}
-          #progress-menu-sub-data role="tabpanel" class="tab-pane"
+          #draft.govuk-tabs__panel.govuk-tabs__panel--hidden
+            h2.govuk-heading-l
+              | Draft
             = render  partial:'pq_draft', locals: {f: f}
-          #progress-menu-pod-data role="tabpanel" class="tab-pane"
+          #pod-check.govuk-tabs__panel.govuk-tabs__panel--hidden
+            h2.govuk-heading-l
+              |
+              abbr title="Private Office Directorate" POD
+              '  check
             = render partial:'pod_check', locals: {f: f}
-          #progress-menu-min-data role="tabpanel" class="tab-pane"
+          #minister-check.govuk-tabs__panel.govuk-tabs__panel--hidden
+            h2.govuk-heading-l
+              | Minister check
             = render partial:'minister_check', locals: {f: f}
-          #progress-menu-answer-data role="tabpanel" class="tab-pane"
+          #answer.govuk-tabs__panel.govuk-tabs__panel--hidden
+            h2.govuk-heading-l
+              | Answer
             = render partial:'answer', locals: {f: f}
-          .form-group
+          #save-button
             = f.submit 'Save', :id => 'save', :class => 'button'


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
The vertical tab style in the details page is replaced with the GDS Design System horizontal tab component. This fixes the tab order issue described in the accessibility review (Section 9.3).

### Screenshots
Current:

![pq-details-tabs-before](https://github.com/user-attachments/assets/28a5bf78-2b7f-4996-9e3d-fef237d193ef)

Proposed:

![pq-details-tabs-after](https://github.com/user-attachments/assets/debf78d7-fcba-4ccb-9ca0-059336493e43)

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/864?selectedIssue=CDPT-1032