### PR TITLE
Revert rack to version 3.1.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,7 +246,7 @@ GEM
     puma (6.4.3)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.1.14)
+    rack (3.1.8)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
Temporarily revert rack gem version to v3.1.8

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->
Just the usual deployment steps

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
All tests should run without error when deployed to each environment.