### PR TITLE
CDPTKAN-1221  Switch on Content Security Policy

### DIFF
--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -21,13 +21,13 @@
 
     <%= javascript_include_tag "application", defer: true %>
 
-    <script>
+    <script nonce="<%= content_security_policy_nonce %>">
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-5RRTCM3');
     </script>
   </head>
 
   <body class="govuk-template__body">
-    <script>
+    <script nonce="<%= content_security_policy_nonce %>">
       document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
     </script>
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,19 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self
+    policy.font_src    :self
+    policy.img_src     :self, :data
+    policy.object_src  :none
+    # 'unsafe-eval' is required by jquery.datetimepicker which uses eval() for date format parsing
+    policy.script_src  :self, :unsafe_eval, "https://www.googletagmanager.com"
+    policy.style_src   :self
+    policy.frame_src   "https://www.googletagmanager.com"
+    policy.connect_src :self, "https://www.google-analytics.com"
+  end
+
+  config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
+  config.content_security_policy_nonce_directives = %w[script-src]
+end


### PR DESCRIPTION
## Description
- Uncomments and configures the CSP initializer (content_security_policy.rb) with policy directives tailored to this app's actual resource requirements
- Adds per-request nonces to both inline <script> tags in govuk_template.html.erb (GTM loader and the js-enabled body class script), which is required for them to execute under a script-src nonce policy
- Restricts scripts to self + Google Tag Manager, with unsafe-eval retained for jquery.datetimepicker's date format parsing; blocks all plugins (object-src: none);  limits frames to GTM and XHR to self + Google Analytics  

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
https://dsdmoj.atlassian.net/browse/CDPTKAN-1221

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
